### PR TITLE
Add `--min-nside` & `--max-nside` with Multiple Iterations

### DIFF
--- a/skymap_scanner/server/choose_new_pixels_to_scan.py
+++ b/skymap_scanner/server/choose_new_pixels_to_scan.py
@@ -16,6 +16,9 @@ from ..load_scan_state import load_cache_state
 # for nside = min_nside.
 # TODO: Should double-check if this makes sense in all cases
 
+MIN_NSIDE_DEFAULT = 8
+MAX_NSIDE_DEFAULT = 512
+
 
 def __healpix_pixel_upgrade(nside, pix):
     pix_nested = healpy.ring2nest(nside, pix)
@@ -167,8 +170,13 @@ def choose_new_pixels_to_scan_around_MCtruth(state_dict, nside, angular_dist=2.*
 
 
 def choose_new_pixels_to_scan(
-    state_dict, max_nside=512, ang_dist=2., min_nside=8
+    state_dict,
+    max_nside=MAX_NSIDE_DEFAULT,
+    ang_dist=2.,
+    min_nside=MIN_NSIDE_DEFAULT,
 ) -> Tuple[icetray.I3Int, icetray.I3Int]:
+    """Get the next set of pixels to scan/refine by searching the state_dict."""
+
     # special case if we have MC truth
     if "MCradec" in state_dict:
         # scan only at max_nside around the true minimum

--- a/skymap_scanner/server/start_scan.py
+++ b/skymap_scanner/server/start_scan.py
@@ -193,15 +193,16 @@ class ProgressReporter:
         else:
             message = "I am starting up the next refinement iteration...\n\n"
 
-        message += f"{self.get_state_dict_report()}\n"
         message += (
+            f"{self.get_state_dict_report()}"  # ends w/ '\n'
             "Config:\n"
             f" - event: {self.event_id}\n"
             f" - min nside: {self.min_nside}\n"
             f" - max nside: {self.max_nside}\n"
             f" - position variations per pixel: {self.nposvar}\n"
+            f"{self.get_processing_stats_report()}"  # ends w/ '\n'
+            f"\n"
         )
-        message += f"{self.get_processing_stats_report()}\n"
 
         if self.scan_ct != self.nscans:
             message += f"I will report back again in {self.report_interval_in_seconds} seconds."

--- a/skymap_scanner/server/start_scan.py
+++ b/skymap_scanner/server/start_scan.py
@@ -191,12 +191,13 @@ class ProgressReporter:
         elapsed = int(time.time() - self.scan_start_time)
         msg = (
             "Processing Stats:\n"
-            f"    * this iteration: ~{int((self.scan_ct/self.nscans)*100)}%, "
+            f" - {self.nposvar} position variations per pixel\n"
+            f" - ~{int((self.scan_ct/self.nscans)*100)}%, "
             f"~{self.scan_ct/self.nposvar}/{self.nscans/self.nposvar} pixels "
-            f"({self.scan_ct}/{self.nscans} scans)\n"
+            f"({self.scan_ct}/{self.nscans} scans) [this iteration]\n"
             f" - Elapsed Runtime\n"
-            f"    * this iteration: {dt.timedelta(seconds=elapsed)}\n"
-            f"    * this iteration + prior processing: {dt.timedelta(seconds=elapsed+self.time_before_scan)}\n"
+            f"    * {dt.timedelta(seconds=elapsed)} [this iteration]\n"
+            f"    * {dt.timedelta(seconds=elapsed+self.time_before_scan)} [this iteration + prior processing]\n"
         )
         if not self.scan_ct:  # we can't predict
             return msg
@@ -207,10 +208,10 @@ class ProgressReporter:
             f" - Rate\n"
             f"    * {secs_per_scan/60*self.nposvar:.2f} min/pixel ({secs_per_scan/60:.2f} min/scan)\n"
             f" - Predicted Time Left\n"
-            f"    * this iteration: {dt.timedelta(seconds=int(secs_predicted-elapsed))}\n"
+            f"    * {dt.timedelta(seconds=int(secs_predicted-elapsed))} [this iteration]\n"
             f" - Predicted Total Runtime\n"
-            f"    * this iteration: {dt.timedelta(seconds=int(secs_predicted))}\n"
-            f"    * this iteration + prior processing: {dt.timedelta(seconds=int(secs_predicted+self.time_before_scan))}\n"
+            f"    * {dt.timedelta(seconds=int(secs_predicted))} [this iteration]\n"
+            f"    * {dt.timedelta(seconds=int(secs_predicted+self.time_before_scan))} [this iteration + prior processing]\n"
         )
         return msg
 

--- a/skymap_scanner/server/start_scan.py
+++ b/skymap_scanner/server/start_scan.py
@@ -197,22 +197,17 @@ class ProgressReporter:
             )
 
         if self.scan_ct == self.nscans:
-            message = (
-                f"I am done scanning this refinement iteration! "
-                f"{self.scan_ct/self.nposvar} total pixels ({self.scan_ct} scans)"
-                "\n"
-            )
+            message = "I am done scanning this refinement iteration! \n"
         else:
-            message = (
-                f"I am busy scanning pixels. "
-                "\n"
-                f"Finished: "
-                f"\n"
-                f" - this iteration: ~{self.scan_ct/self.nposvar}/{self.nscans/self.nposvar} pixels, "
-                f"~{int((self.scan_ct/self.nscans)*100)}% ({self.scan_ct}/{self.nscans} scans)"
-                "\n"
-            )
+            message = "I am busy scanning pixels. \n"
 
+        message += (
+            f"Stats: "
+            f"\n"
+            f" - this iteration: ~{self.scan_ct/self.nposvar}/{self.nscans/self.nposvar} pixels, "
+            f"~{int((self.scan_ct/self.nscans)*100)}% ({self.scan_ct}/{self.nscans} scans)"
+            "\n"
+        )
         message += f"{time_stat()}\n"
         message += "Pixel Summary:\n"
         message += f" - {self.nposvar} position variations per pixel\n"

--- a/skymap_scanner/server/start_scan.py
+++ b/skymap_scanner/server/start_scan.py
@@ -168,8 +168,11 @@ class ProgressReporter:
         def time_stat() -> str:
             elapsed = int(time.time() - self.scan_start_time)
             runtime_msg = (
-                f"Elapsed Runtime: {dt.timedelta(seconds=elapsed+self.time_before_scan)} "
-                f"({dt.timedelta(seconds=elapsed)} spent scanning this refinement iteration)"
+                f"Elapsed Runtime: "
+                f"\n"
+                f" - this iteration: {dt.timedelta(seconds=elapsed)}"
+                f"\n"
+                f" - this iteration + prior processing: {dt.timedelta(seconds=elapsed+self.time_before_scan)}"
             )
             if not self.scan_ct:
                 return runtime_msg
@@ -178,18 +181,24 @@ class ProgressReporter:
             return (
                 f"{runtime_msg} "
                 f"\n"
-                f"Rate: {secs_per_scan/60*self.nposvar:.2f} min/pixel "
-                f"({secs_per_scan/60:.2f} min/scan)"
+                f"Rate: "
                 f"\n"
-                f"Predicted Refinement-Iteration Finish: {dt.timedelta(seconds=int(secs_predicted-elapsed))} from now "
+                f" - {secs_per_scan/60*self.nposvar:.2f} min/pixel ({secs_per_scan/60:.2f} min/scan)"
                 f"\n"
-                f"Predicted Elapsed Runtime at End of Refinement-Iteration: "
-                f"{dt.timedelta(seconds=int(secs_predicted+self.time_before_scan))})"
+                f"Predicted Time Left: "
+                f"\n"
+                f" - this iteration: {dt.timedelta(seconds=int(secs_predicted-elapsed))}"
+                f"\n"
+                f"Predicted Total Runtime: "
+                f"\n"
+                f" - this iteration: {dt.timedelta(seconds=int(secs_predicted))}"
+                f"\n"
+                f" - this iteration + prior processing: {dt.timedelta(seconds=int(secs_predicted+self.time_before_scan))}"
             )
 
         if self.scan_ct == self.nscans:
             message = (
-                f"I am done scanning! "
+                f"I am done scanning this refinement iteration! "
                 f"{self.scan_ct/self.nposvar} total pixels ({self.scan_ct} scans)"
                 "\n"
             )
@@ -197,13 +206,16 @@ class ProgressReporter:
             message = (
                 f"I am busy scanning pixels. "
                 "\n"
-                f"Finished: ~{self.scan_ct/self.nposvar}/{self.nscans/self.nposvar} pixels, "
+                f"Finished: "
+                f"\n"
+                f" - this iteration: ~{self.scan_ct/self.nposvar}/{self.nscans/self.nposvar} pixels, "
                 f"~{int((self.scan_ct/self.nscans)*100)}% ({self.scan_ct}/{self.nscans} scans)"
                 "\n"
             )
 
         message += f"{time_stat()}\n"
-        message += f"{self.nposvar} position variations per pixel\n"
+        message += "Pixel Summary:\n"
+        message += f" - {self.nposvar} position variations per pixel\n"
 
         if len(self.state_dict["nsides"])==0:
             message += " - no pixels are done yet\n"

--- a/skymap_scanner/server/start_scan.py
+++ b/skymap_scanner/server/start_scan.py
@@ -178,8 +178,8 @@ class ProgressReporter:
         else:
             message = "I am busy scanning pixels.\n\n"
 
-        message += f"{self.get_processing_stats_report()}\n"
         message += f"{self.get_state_dict_report()}\n"
+        message += f"{self.get_processing_stats_report()}\n"
 
         if self.scan_ct != self.nscans:
             message += f"I will report back again in {self.report_interval_in_seconds} seconds."

--- a/skymap_scanner/server/start_scan.py
+++ b/skymap_scanner/server/start_scan.py
@@ -188,8 +188,10 @@ class ProgressReporter:
         """Make a status report string."""
         if self.scan_ct == self.nscans:
             message = "I am done scanning this refinement iteration!\n\n"
-        else:
+        elif self.scan_ct:
             message = "I am busy scanning pixels.\n\n"
+        else:
+            message = "I am starting up the next refinement iteration...\n\n"
 
         message += f"{self.get_state_dict_report()}\n"
         message += (
@@ -238,7 +240,7 @@ class ProgressReporter:
         """Get a multi-line progress report of the state_dict's nside contents."""
         msg = ""
         if not self.state_dict["nsides"]:
-            msg += "Iterations:\n "
+            msg += "Iterations with Saved Pixels:\n "
             msg += " - no pixels are done yet\n"
         else:
 

--- a/skymap_scanner/server/start_scan.py
+++ b/skymap_scanner/server/start_scan.py
@@ -197,7 +197,7 @@ class ProgressReporter:
             f" - event: {self.event_id}\n"
             f" - min nside: {self.min_nside}\n"
             f" - max nside: {self.max_nside}\n"
-            f" - {self.nposvar} position variations per pixel\n"
+            f" - position variations per pixel: {self.nposvar}\n"
         )
         message += f"{self.get_processing_stats_report()}\n"
 
@@ -211,9 +211,9 @@ class ProgressReporter:
         elapsed = int(time.time() - self.scan_start_time)
         msg = (
             "Processing Stats:\n"
-            f" - ~{int((self.scan_ct/self.nscans)*100)}%, "
-            f"~{self.scan_ct/self.nposvar}/{self.nscans/self.nposvar} pixels "
-            f"({self.scan_ct}/{self.nscans} scans) [this iteration]\n"
+            f" - {((self.scan_ct/self.nscans)*100):.1f}% "
+            f"({self.scan_ct/self.nposvar}/{self.nscans/self.nposvar} pixels, "
+            f"{self.scan_ct}/{self.nscans} scans) [this iteration]\n"
             f" - Elapsed Runtime\n"
             f"    * {dt.timedelta(seconds=elapsed)} [this iteration]\n"
             f"    * {dt.timedelta(seconds=elapsed+self.time_before_scan)} [this iteration + prior processing]\n"

--- a/skymap_scanner/server/start_scan.py
+++ b/skymap_scanner/server/start_scan.py
@@ -827,7 +827,7 @@ def main() -> None:
     parser.add_argument(
         "--max-nside",
         default=MAX_NSIDE_DEFAULT,
-        help="The final refinement iteration's nside value",  # TODO: is that right?
+        help="The final refinement iteration's nside value",
         type=lambda x: int(
             _validate_arg(
                 x,

--- a/skymap_scanner/server/start_scan.py
+++ b/skymap_scanner/server/start_scan.py
@@ -219,38 +219,17 @@ class ProgressReporter:
         """Get a multi-line progress report of the state_dict's nside contents."""
         msg = ""
         if not self.state_dict["nsides"]:
+            msg += "Iterations:\n "
             msg += " - no pixels are done yet\n"
         else:
-            with_pixels: List[Tuple[int, int]] = []
-            no_pixels: List[Tuple[int, int]] = []
-
-            for nside in sorted(self.state_dict["nsides"]):  # sorted keys
-                npixels = len(self.state_dict["nsides"][nside])
-                if npixels:
-                    with_pixels.append((nside, npixels))
-                else:
-                    no_pixels.append((nside, npixels))
-
-            # the current nside is either the last "with pixels" or the first "without"
-            if self.scan_ct:
-                # if we've collected a pixel-scan, then we found the in-progress iteration
-                in_progress = with_pixels.pop()
-            else:
-                in_progress = no_pixels.pop(0)
 
             def nside_line(nside: int, npixels: int) -> str:
                 return f" - {npixels} pixels, nside={nside}\n"
 
-            msg += "Iteration in Progress:\n"
-            msg += nside_line(in_progress[0], in_progress[1])
-            msg += "Completed Iterations:\n"
-            for nside, npixels in with_pixels:
-                msg += nside_line(nside, npixels)
-            msg += "Remaining Iterations:\n"
-            for nside, npixels in no_pixels:
-                msg += nside_line(nside, npixels)
+            msg += "Iterations:\n"
+            for nside in sorted(self.state_dict["nsides"]):  # sorted by nside
+                msg += nside_line(nside, len(self.state_dict["nsides"][nside]))
 
-        msg += f" - {self.nposvar} position variations per pixel\n"
         return msg
 
     def finish(self) -> None:

--- a/skymap_scanner/server/start_scan.py
+++ b/skymap_scanner/server/start_scan.py
@@ -239,16 +239,14 @@ class ProgressReporter:
 
     def get_state_dict_report(self) -> str:
         """Get a multi-line progress report of the state_dict's nside contents."""
-        msg = ""
+        msg = "Iterations with Saved Pixels:\n"
         if not self.state_dict["nsides"]:
-            msg += "Iterations with Saved Pixels:\n "
             msg += " - no pixels are done yet\n"
         else:
 
             def nside_line(nside: int, npixels: int) -> str:
                 return f" - {npixels} pixels, nside={nside}\n"
 
-            msg += "Iterations:\n"
             for nside in sorted(self.state_dict["nsides"]):  # sorted by nside
                 msg += nside_line(nside, len(self.state_dict["nsides"][nside]))
 

--- a/skymap_scanner/server/start_scan.py
+++ b/skymap_scanner/server/start_scan.py
@@ -39,7 +39,11 @@ from ..utils import (
     pixel_to_tuple,
     save_GCD_frame_packet_to_file,
 )
-from .choose_new_pixels_to_scan import choose_new_pixels_to_scan
+from .choose_new_pixels_to_scan import (
+    MAX_NSIDE_DEFAULT,
+    MIN_NSIDE_DEFAULT,
+    choose_new_pixels_to_scan,
+)
 
 NSidePixelPair = Tuple[icetray.I3Int, icetray.I3Int]
 

--- a/tests/docker_scripts/launch_server.sh
+++ b/tests/docker_scripts/launch_server.sh
@@ -14,6 +14,6 @@ docker run --network="host" --rm -i \
     --gcd-dir /local/gcd-dir \
     --broker $PULSAR_ADDRESS \
     --log DEBUG \
-    --mini-test-variations
-    # --min-nside 1 \
-    # --max-nside 1
+    --mini-test-variations \
+    --min-nside 1 \
+    --max-nside 1

--- a/tests/docker_scripts/launch_server.sh
+++ b/tests/docker_scripts/launch_server.sh
@@ -14,4 +14,6 @@ docker run --network="host" --rm -i \
     --gcd-dir /local/gcd-dir \
     --broker $PULSAR_ADDRESS \
     --log DEBUG \
-    --mini-test-variations
+    --mini-test-variations \
+    --min-nside 1 \
+    --max-nside 1

--- a/tests/docker_scripts/launch_server.sh
+++ b/tests/docker_scripts/launch_server.sh
@@ -14,6 +14,6 @@ docker run --network="host" --rm -i \
     --gcd-dir /local/gcd-dir \
     --broker $PULSAR_ADDRESS \
     --log DEBUG \
-    --mini-test-variations \
-    --min-nside 1 \
-    --max-nside 1
+    --mini-test-variations
+    # --min-nside 1 \
+    # --max-nside 1

--- a/tests/docker_scripts/launch_server.sh
+++ b/tests/docker_scripts/launch_server.sh
@@ -16,4 +16,4 @@ docker run --network="host" --rm -i \
     --log DEBUG \
     --mini-test-variations \
     --min-nside 1 \
-    --max-nside 1
+    --max-nside 512

--- a/tests/docker_scripts/launch_server.sh
+++ b/tests/docker_scripts/launch_server.sh
@@ -14,4 +14,4 @@ docker run --network="host" --rm -i \
     --gcd-dir /local/gcd-dir \
     --broker $PULSAR_ADDRESS \
     --log DEBUG \
-    --mini-test-scan
+    --mini-test-variations

--- a/tests/docker_scripts/launch_server.sh
+++ b/tests/docker_scripts/launch_server.sh
@@ -16,4 +16,4 @@ docker run --network="host" --rm -i \
     --log DEBUG \
     --mini-test-variations \
     --min-nside 1 \
-    --max-nside 512
+    --max-nside 1


### PR DESCRIPTION
Add back the multiple-iteration/nside functionality. While doing this, make `min_nside` & `max_nside` configurable from the command line.

From Slack:
> It looks like I removed the "zooming" functionality... I can fix this. In summary, IceTray goes back to the top module after the last module is complete (of course), but the non-IceTray server code I wrote does not do this. It simply ends after what would be "one icetray iteration". 