### PR TITLE
Add `--client-args-json` for Condor Launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,24 +42,24 @@ singularity run skymap_scanner.sif \
 ##### Figure Your Args
 ```
     --broker BROKER_ADDRESS \
-    --auth-token `cat ~/skyscan-broker.token` \
+    --auth-token AUTH_TOKEN \
     --timeout-to-clients SOME_NUMBER__BUT_FYI_THERES_A_DEFAULT \
     --timeout-from-clients SOME_NUMBER__BUT_FYI_THERES_A_DEFAULT
 ```
 _NOTE: There are more CL arguments not shown. They have defaults._
 ##### Run It
 ###### with Condor (via Singularity)
-You'll want to put your `skymap_scanner.client` args in a file, then pass that to the helper script.
+You'll want to put your `skymap_scanner.client` args in a JSON file, then pass that to the helper script.
 ```
-echo $YOUR_ARGS > my_client_args.txt  # just an example
+echo my_client_args.json  # just an example
 ./scripts/launch_scripts/condor/spawn_condor_clients.py \
     --jobs #### \
     --memory #GB \
     --singularity-image URL_OR_PATH_TO_SINGULARITY_IMAGE \
     --startup-json PATH_TO_STARTUP_JSON \
-    --client-args-file my_client_args.txt
+    --client-args-json my_client_args.json
 ```
-_NOTE: `spawn_condor_clients.py` will wait until `--startup-json PATH_TO_STARTUP_JSON` exists, since it needs to file-transfer it to the worker node. Similarly, `--startup-json-dir` is auto-set by the script and thus, is disallowed from being in the `--client-args-file` file._
+_NOTE: `spawn_condor_clients.py` will wait until `--startup-json PATH_TO_STARTUP_JSON` exists, since it needs to file-transfer it to the worker node. Similarly, `--startup-json-dir` is auto-set by the script and thus, is disallowed from being in the `--client-args-json` file._
 ###### or Manually (Docker)
 ```
 ./scripts/launch_scripts/wait_for_startup_json.sh DIR_WITH_STARTUP_JSON

--- a/scripts/condor/spawn_condor_clients.py
+++ b/scripts/condor/spawn_condor_clients.py
@@ -3,6 +3,7 @@
 import argparse
 import datetime as dt
 import getpass
+import json
 import logging
 import os
 import subprocess
@@ -146,9 +147,9 @@ def main() -> None:
         type=lambda x: wait_for_file(x, 60 * 25),
     )
     parser.add_argument(
-        "--client-args-file",
+        "--client-args-json",
         required=True,
-        help="a text file containing the python CL arguments to pass to skymap_scanner.client",
+        help="a JSON file containing the python CL arguments to pass to skymap_scanner.client",
     )
 
     args = parser.parse_args()
@@ -159,12 +160,12 @@ def main() -> None:
     scratch = make_condor_scratch_dir()
 
     # get client args
-    with open(args.client_args_file) as f:
-        client_args = f.read()
+    with open(args.client_args_json) as f:
+        client_args = " ".join(f"{k} {v}" for k, v in json.load(f).items())
         logging.info(f"Client Args: {client_args}")
     if "--startup-json-dir" in client_args:
         raise RuntimeError(
-            "The '--client-args-file' file cannot include \"--startup-json-dir\". "
+            "The '--client-args-json' file cannot include \"--startup-json-dir\". "
             "This needs to be defined explicitly with '--startup-json'."
         )
     client_args += " --startup-json-dir . "  # actual file will be transferred

--- a/scripts/condor/spawn_condor_clients.py
+++ b/scripts/condor/spawn_condor_clients.py
@@ -52,7 +52,7 @@ def make_condor_file(  # pylint: disable=R0913,R0914
         # write
         file.write(
             f"""executable = python
-arguments = -m skymap_scanner.client {client_args}
+arguments = -m skymap_scanner.client {client_args} --startup-json-dir .
 +SingularityImage = "{singularity_image}"
 output = {scratch}/skymap_scanner.out
 error = {scratch}/skymap_scanner.err
@@ -168,7 +168,6 @@ def main() -> None:
             "The '--client-args-json' file cannot include \"--startup-json-dir\". "
             "This needs to be defined explicitly with '--startup-json'."
         )
-    client_args += " --startup-json-dir . "  # actual file will be transferred
 
     # make condor file
     condorpath = make_condor_file(


### PR DESCRIPTION
Replaces text file with JSON file for condor launch script.

JSON doesn't have whitespace issues