### PR TITLE
new smaller Docker images with pulsar

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
           mkdir $SKYSCAN_OUTPUT_DIR
 
           # Launch Server
-          singularity run /tmp/skymap_scanner.sif \
+          singularity run skymap_scanner.sif \
             python -m skymap_scanner.server \
             --reco-algo dummy \
             --event-file $REALTIME_EVENTS_DIR/hese_event_01.json \
@@ -100,7 +100,7 @@ jobs:
           mkdir $SKYSCAN_DEBUG_DIR
           export PULSAR_UNACKED_MESSAGES_TIMEOUT_SEC=1800  # 30 mins
           for i in $( seq 1 $nclients ); do
-            singularity run /tmp/skymap_scanner.sif \
+            singularity run skymap_scanner.sif \
               python -m skymap_scanner.client \
               --startup-json-dir . \
               --broker $BROKER_ADDRESS \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,22 @@ jobs:
   test-build-docker:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          file: ./Dockerfile
+          tags: icecube/skymap_scanner:local
+
+  test-run-singularity-dummy-reco:
+    runs-on: ubuntu-latest
+    needs: test-build-docker
+    steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:
@@ -34,57 +50,17 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          no-cache: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           file: ./Dockerfile
           tags: icecube/skymap_scanner:local
-          outputs: type=docker,dest=/tmp/myimage.tar
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: dockerimage
-          path: /tmp/myimage.tar
-
-  test-build-singularity:
-    runs-on: ubuntu-latest
-    needs: test-build-docker
-    steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: 'true'
       - uses: eWaterCycle/setup-apptainer@v2
         with:
           apptainer-version: 1.1.2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v12
-      - name: Download artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: dockerimage
-          path: /tmp
-      - name: Load Docker image
-        run: |
-          docker load --input /tmp/myimage.tar
       - name: Build Singularity Image
         run: |
           sudo singularity build skymap_scanner.sif docker-daemon://icecube/skymap_scanner:local
           ls -lh skymap_scanner.sif
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: singimage
-          path: skymap_scanner.sif
-
-  test-run-singularity-dummy-reco:
-    runs-on: ubuntu-latest
-    needs: test-build-singularity
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: singimage
-          path: /tmp
-      - uses: actions/checkout@v3
       - name: Checkout MQClient repo (for broker startup scripts)
         uses: actions/checkout@v3
         with:
@@ -94,9 +70,6 @@ jobs:
         run: |
           set -x
           ./MQClient/resources/docker-pulsar.sh
-      - uses: eWaterCycle/setup-apptainer@v2
-        with:
-          apptainer-version: 1.1.2
       - name: Run Singularity Container
         run: |
           mkdir $SKYSCAN_CACHE_DIR
@@ -173,16 +146,15 @@ jobs:
           set -x
           ./MQClient/resources/docker-pulsar.sh
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v12
-      - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: docker/setup-buildx-action@v2
+      - name: Build and push
+        uses: docker/build-push-action@v3
         with:
-          name: dockerimage
-          path: /tmp
-      - name: Load Docker image
-        run: |
-          docker load --input /tmp/myimage.tar
-          rm /tmp/myimage.tar
+          context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          file: ./Dockerfile
+          tags: icecube/skymap_scanner:local
       - name: Run
         run: |
           set -x
@@ -255,16 +227,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v12
-      - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: docker/setup-buildx-action@v2
+      - name: Build and push
+        uses: docker/build-push-action@v3
         with:
-          name: dockerimage
-          path: /tmp
-      - name: Load Docker image
-        run: |
-          docker load --input /tmp/myimage.tar
-          rm /tmp/myimage.tar
+          context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          file: ./Dockerfile
+          tags: icecube/skymap_scanner:local
       - name: Run
         run: |
           # grab the GCDQp_packet key and throw into a file

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,36 +20,70 @@ env:
 
 jobs:
 
-  test-build-images:
+  test-build-docker:
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space (Ubuntu)
-        #uses: jlumbroso/free-disk-space@main
-        # use fork for now https://github.com/jlumbroso/free-disk-space/issues/1
-        uses: marksiasol/free-disk-space@main
+        uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: 'true'
       - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          no-cache: true
+          file: ./Dockerfile
+          tags: icecube/skymap_scanner:local
+          outputs: type=docker,dest=/tmp/myimage.tar
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: dockerimage
+          path: /tmp/myimage.tar
+
+  test-build-singularity:
+    runs-on: ubuntu-latest
+    needs: test-build-docker
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: 'true'
       - uses: eWaterCycle/setup-apptainer@v2
         with:
           apptainer-version: 1.1.2
-      - name: Build Docker Image
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v12
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: dockerimage
+          path: /tmp
+      - name: Load Docker image
         run: |
-          docker build --no-cache -t icecube/skymap_scanner:local .
+          docker load --input /tmp/myimage.tar
       - name: Build Singularity Image
         run: |
           sudo singularity build skymap_scanner.sif docker-daemon://icecube/skymap_scanner:local
           ls -lh skymap_scanner.sif
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: singimage
+          path: skymap_scanner.sif
 
   test-run-singularity-dummy-reco:
     runs-on: ubuntu-latest
+    needs: test-build-singularity
     steps:
-      - name: Free Disk Space (Ubuntu)
-        #uses: jlumbroso/free-disk-space@main
-        # use fork for now https://github.com/jlumbroso/free-disk-space/issues/1
-        uses: marksiasol/free-disk-space@main
+      - name: Download artifact
+        uses: actions/download-artifact@v2
         with:
-          tool-cache: 'true'
+          name: singimage
+          path: /tmp
       - uses: actions/checkout@v3
       - name: Checkout MQClient repo (for broker startup scripts)
         uses: actions/checkout@v3
@@ -63,20 +97,13 @@ jobs:
       - uses: eWaterCycle/setup-apptainer@v2
         with:
           apptainer-version: 1.1.2
-      - name: Build Docker Image
-        run: |
-          docker build --no-cache -t icecube/skymap_scanner:local .
-      - name: Build Singularity Image
-        run: |
-          sudo singularity build skymap_scanner.sif docker-daemon://icecube/skymap_scanner:local
-          ls -lh skymap_scanner.sif
       - name: Run Singularity Container
         run: |
           mkdir $SKYSCAN_CACHE_DIR
           mkdir $SKYSCAN_OUTPUT_DIR
 
           # Launch Server
-          singularity run skymap_scanner.sif \
+          singularity run /tmp/skymap_scanner.sif \
             python -m skymap_scanner.server \
             --reco-algo dummy \
             --event-file $REALTIME_EVENTS_DIR/hese_event_01.json \
@@ -99,7 +126,7 @@ jobs:
           mkdir $SKYSCAN_DEBUG_DIR
           export PULSAR_UNACKED_MESSAGES_TIMEOUT_SEC=1800  # 30 mins
           for i in $( seq 1 $nclients ); do
-            singularity run skymap_scanner.sif \
+            singularity run /tmp/skymap_scanner.sif \
               python -m skymap_scanner.client \
               --startup-json-dir . \
               --broker $BROKER_ADDRESS \
@@ -123,6 +150,7 @@ jobs:
 
   test-run-docker:
     runs-on: ubuntu-latest
+    needs: test-build-docker
     strategy:
       fail-fast: false
       matrix:
@@ -144,9 +172,17 @@ jobs:
         run: |
           set -x
           ./MQClient/resources/docker-pulsar.sh
-      - name: Build Skymap Scanner Docker Image
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v12
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: dockerimage
+          path: /tmp
+      - name: Load Docker image
         run: |
-          docker build --no-cache -t icecube/skymap_scanner:local .
+          docker load --input /tmp/myimage.tar
+          rm /tmp/myimage.tar
       - name: Run
         run: |
           set -x
@@ -207,6 +243,7 @@ jobs:
 
   test-run-one-reco-icetray:
     runs-on: ubuntu-latest
+    needs: test-build-docker
     strategy:
       fail-fast: false
       matrix:
@@ -217,9 +254,17 @@ jobs:
         ]
     steps:
       - uses: actions/checkout@v3
-      - name: Build Skymap Scanner Docker Image
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v12
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: dockerimage
+          path: /tmp
+      - name: Load Docker image
         run: |
-          docker build --no-cache -t icecube/skymap_scanner:local .
+          docker load --input /tmp/myimage.tar
+          rm /tmp/myimage.tar
       - name: Run
         run: |
           # grab the GCDQp_packet key and throw into a file

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
           context: .
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          file: ./Dockerfile
+          file: Dockerfile
           tags: icecube/skymap_scanner:local
 
   test-run-singularity-dummy-reco:
@@ -52,8 +52,9 @@ jobs:
           context: .
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          file: ./Dockerfile
+          file: Dockerfile
           tags: icecube/skymap_scanner:local
+          load: true
       - uses: eWaterCycle/setup-apptainer@v2
         with:
           apptainer-version: 1.1.2
@@ -153,8 +154,9 @@ jobs:
           context: .
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          file: ./Dockerfile
+          file: Dockerfile
           tags: icecube/skymap_scanner:local
+          load: true
       - name: Run
         run: |
           set -x
@@ -234,8 +236,9 @@ jobs:
           context: .
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          file: ./Dockerfile
+          file: Dockerfile
           tags: icecube/skymap_scanner:local
+          load: true
       - name: Run
         run: |
           # grab the GCDQp_packet key and throw into a file

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM icecube/icetray:icetray-devel-v1.4.1-ubuntu22.04-2022-11-29 as build
+#
+# Define the base image icetray version
+#
+ARG ICETRAY_VERSION=v1.4.1-ubuntu22.04-2022-11-29
+
+FROM icecube/icetray:icetray-devel-$ICETRAY_VERSION as build
 
 #
 # Add Packages
@@ -23,7 +28,7 @@ RUN cd pulsar-client-python && git submodule update --init \
 #
 # Now make the prod image
 #
-FROM icecube/icetray:icetray-prod-v1.4.1-ubuntu22.04-2022-11-29 as prod 
+FROM icecube/icetray:icetray-prod-$ICETRAY_VERSION as prod
 
 
 #
@@ -86,8 +91,7 @@ RUN pip install .
 
 #
 # ENTRYPOINT
+# Inherited from icetray image as /usr/local/icetray/env-shell.sh
 #
 
-# set the entry point so that module is called with any parameters given to the `docker run` command
-#ENTRYPOINT ["/bin/bash", "/usr/local/icetray/env-shell.sh"]
 CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,17 +62,17 @@ RUN tree -f $I3_DATA
 RUN apt-get update 
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends apt-utils
 RUN apt-get update 
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y bzip2 zstd default-jre protobuf-compiler python3-pybind11 python3-pip 
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y bzip2 zstd protobuf-compiler python3-pybind11 python3-pip 
 RUN apt-get clean
 
 #
 # Manually compile Pulsar
 #
 RUN git clone https://github.com/apache/pulsar-client-cpp
-RUN cd pulsar-client-cpp && cmake -DBUILD_TESTS=OFF . && make -j2
+RUN cd pulsar-client-cpp && cmake -DBUILD_TESTS=OFF . && make -j2 && make install
 RUN git clone https://github.com/apache/pulsar-client-python
 RUN cd pulsar-client-python && git submodule update --init \
-    && cmake -DCMAKE_PREFIX_PATH=../pulsar-client-cpp -B build \
+    && cmake -B build \
     && cmake --build build && cmake --install build \
     && python3 ./setup.py bdist_wheel \
     && python3 -m pip install dist/pulsar_client-*.whl --force-reinstall

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,61 @@
-FROM icecube/icetray:icetray-devel-v1.4.1-ubuntu22.04-2022-11-29
+FROM icecube/icetray:icetray-devel-v1.4.1-ubuntu22.04-2022-11-29 as build
 
 #
-# Get Data
+# Add Packages
 #
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y zstd libzstd-dev protobuf-compiler python3-pybind11 python3-pip && \
+    apt-get clean
+
+#
+# Manually compile Pulsar
+#
+WORKDIR /local
+RUN git clone https://github.com/apache/pulsar-client-cpp
+RUN cd pulsar-client-cpp && cmake -DBUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release . && make -j2 && make install
+RUN git clone https://github.com/apache/pulsar-client-python
+RUN cd pulsar-client-python && git submodule update --init \
+    && cmake -B build \
+    && cmake --build build && cmake --install build \
+    && python3 ./setup.py bdist_wheel
+
+
+#
+# Now make the prod image
+#
+FROM icecube/icetray:icetray-prod-v1.4.1-ubuntu22.04-2022-11-29 as prod 
+
+
+#
+# Add Packages
+#
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y libprotobuf23 python3-pybind11 python3-pip && \
+    apt-get clean
+
+
+#
+# Copy pulsar
+#
+WORKDIR /local
+COPY --from=build /usr/local/include/pulsar/ /usr/local/include/pulsar/
+COPY --from=build /usr/local/lib/libpulsar* /usr/local/lib/
+COPY --from=build /local/pulsar-client-python/dist/ pulsar-client-python/
+RUN python3 -m pip install pulsar-client-python/pulsar_client-*.whl
+
+
 
 # we need more spline tables (since we need to potentially re-do onlineL2)
-RUN mkdir -p /opt/i3-data/photon-tables/splines/
-RUN ls /opt/i3-data
-RUN wget -nv -t 5 -O /opt/i3-data/photon-tables/splines/InfBareMu_mie_abs_z20a10_V2.fits \
-        http://prod-exe.icecube.wisc.edu/spline-tables/InfBareMu_mie_abs_z20a10_V2.fits
-RUN wget -nv -t 5 -O /opt/i3-data/photon-tables/splines/InfBareMu_mie_prob_z20a10_V2.fits \
-        http://prod-exe.icecube.wisc.edu/spline-tables/InfBareMu_mie_prob_z20a10_V2.fits
-RUN wget -nv -t 5 -O /opt/i3-data/photon-tables/splines/cascade_single_spice_bfr-v2_flat_z20_a5.abs.fits \
-        http://prod-exe.icecube.wisc.edu/spline-tables/cascade_single_spice_bfr-v2_flat_z20_a5.abs.fits
-RUN wget -nv -t 5 -O /opt/i3-data/photon-tables/splines/cascade_single_spice_bfr-v2_flat_z20_a5.prob.fits \
-        http://prod-exe.icecube.wisc.edu/spline-tables/cascade_single_spice_bfr-v2_flat_z20_a5.prob.fits
-RUN wget -nv -t 5 -O /opt/i3-data/photon-tables/splines/cascade_effectivedistance_spice_bfr-v2_z20.eff.fits \
-        http://prod-exe.icecube.wisc.edu/spline-tables/cascade_effectivedistance_spice_bfr-v2_z20.eff.fits
-
-# install baseline GCDs
-RUN mkdir /opt/i3-data/baseline_gcds
-RUN wget -nv -N -t 5 -P /opt/i3-data/baseline_gcds -r -l 1 -A *.i3* -nd https://icecube:skua@convey.icecube.wisc.edu/data/user/followup/baseline_gcds/ && \
-    chmod -R u+rwX,go+rX,go-w /opt/i3-data/baseline_gcds
-RUN ls /opt/i3-data/baseline_gcds
+#RUN wget -nv -t 5 -O /opt/i3-data/photon-tables/splines/InfBareMu_mie_abs_z20a10_V2.fits \
+#        http://prod-exe.icecube.wisc.edu/spline-tables/InfBareMu_mie_abs_z20a10_V2.fits
+#RUN wget -nv -t 5 -O /opt/i3-data/photon-tables/splines/InfBareMu_mie_prob_z20a10_V2.fits \
+#        http://prod-exe.icecube.wisc.edu/spline-tables/InfBareMu_mie_prob_z20a10_V2.fits
+#RUN wget -nv -t 5 -O /opt/i3-data/photon-tables/splines/cascade_single_spice_bfr-v2_flat_z20_a5.abs.fits \
+#        http://prod-exe.icecube.wisc.edu/spline-tables/cascade_single_spice_bfr-v2_flat_z20_a5.abs.fits
+#RUN wget -nv -t 5 -O /opt/i3-data/photon-tables/splines/cascade_single_spice_bfr-v2_flat_z20_a5.prob.fits \
+#        http://prod-exe.icecube.wisc.edu/spline-tables/cascade_single_spice_bfr-v2_flat_z20_a5.prob.fits
+#RUN wget -nv -t 5 -O /opt/i3-data/photon-tables/splines/cascade_effectivedistance_spice_bfr-v2_z20.eff.fits \
+#        http://prod-exe.icecube.wisc.edu/spline-tables/cascade_effectivedistance_spice_bfr-v2_z20.eff.fits
 
 
 #
@@ -30,56 +63,24 @@ RUN ls /opt/i3-data/baseline_gcds
 #
 
 # add realtime_gfu python checkout from V21-06-00
-RUN svn co http://code.icecube.wisc.edu/svn/meta-projects/realtime/releases/V21-06-00/realtime_gfu \
-        /usr/local/icetray/realtime_gfu --username=icecube --password=skua --no-auth-cache && \
-    ln -sf /usr/local/icetray/realtime_gfu/python /usr/local/icetray/lib/icecube/realtime_gfu
+#RUN svn co http://code.icecube.wisc.edu/svn/meta-projects/realtime/releases/V21-06-00/realtime_gfu \
+#        /usr/local/icetray/realtime_gfu --username=icecube --password=skua --no-auth-cache && \
+#    ln -sf /usr/local/icetray/realtime_gfu/python /usr/local/icetray/lib/icecube/realtime_gfu
 # add realtime_hese
-RUN svn co http://code.icecube.wisc.edu/svn/meta-projects/realtime/releases/V21-06-00/realtime_hese \
-        /usr/local/icetray/realtime_hese --username=icecube --password=skua --no-auth-cache && \
-    ln -sf /usr/local/icetray/realtime_hese/python /usr/local/icetray/lib/icecube/realtime_hese
+#RUN svn co http://code.icecube.wisc.edu/svn/meta-projects/realtime/releases/V21-06-00/realtime_hese \
+#        /usr/local/icetray/realtime_hese --username=icecube --password=skua --no-auth-cache && \
+#    ln -sf /usr/local/icetray/realtime_hese/python /usr/local/icetray/lib/icecube/realtime_hese
 # add realtime_tools
-RUN svn co http://code.icecube.wisc.edu/svn/meta-projects/realtime/releases/V21-06-00/realtime_tools \
-        /usr/local/icetray/realtime_tools --username=icecube --password=skua --no-auth-cache && \
-    ln -sf /usr/local/icetray/realtime_tools/python /usr/local/icetray/lib/icecube/realtime_tools
+#RUN svn co http://code.icecube.wisc.edu/svn/meta-projects/realtime/releases/V21-06-00/realtime_tools \
+#        /usr/local/icetray/realtime_tools --username=icecube --password=skua --no-auth-cache && \
+#    ln -sf /usr/local/icetray/realtime_tools/python /usr/local/icetray/lib/icecube/realtime_tools
 
-
-#
-# Get directory tree organized
-#
-
-WORKDIR /local
-COPY . .
-
-RUN apt-get install tree
-RUN tree -f /local
-RUN tree -f $I3_TESTDATA
-RUN tree -f $I3_DATA
-
-
-#
-# Add Packages
-#
-RUN apt-get update 
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends apt-utils
-RUN apt-get update 
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y bzip2 zstd protobuf-compiler python3-pybind11 python3-pip 
-RUN apt-get clean
-
-#
-# Manually compile Pulsar
-#
-RUN git clone https://github.com/apache/pulsar-client-cpp
-RUN cd pulsar-client-cpp && cmake -DBUILD_TESTS=OFF . && make -j2 && make install
-RUN git clone https://github.com/apache/pulsar-client-python
-RUN cd pulsar-client-python && git submodule update --init \
-    && cmake -B build \
-    && cmake --build build && cmake --install build \
-    && python3 ./setup.py bdist_wheel \
-    && python3 -m pip install dist/pulsar_client-*.whl --force-reinstall
 
 #
 # Add Python Packages
 #
+WORKDIR /local
+COPY . .
 RUN pip install .
 
 
@@ -88,5 +89,5 @@ RUN pip install .
 #
 
 # set the entry point so that module is called with any parameters given to the `docker run` command
-ENTRYPOINT ["/bin/bash", "/usr/local/icetray/env-shell.sh"]
+#ENTRYPOINT ["/bin/bash", "/usr/local/icetray/env-shell.sh"]
 CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,20 +57,29 @@ RUN tree -f $I3_DATA
 
 
 #
+# Add Packages
+#
+RUN apt-get update 
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends apt-utils
+RUN apt-get update 
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y bzip2 zstd default-jre protobuf-compiler python3-pybind11 python3-pip 
+RUN apt-get clean
+
+#
+# Manually compile Pulsar
+#
+RUN git clone https://github.com/apache/pulsar-client-cpp
+RUN cd pulsar-client-cpp && cmake -DBUILD_TESTS=OFF . && make -j2
+RUN git clone https://github.com/apache/pulsar-client-python
+RUN cd pulsar-client-python && git submodule update --init \
+    && cmake -DCMAKE_PREFIX_PATH=../pulsar-client-cpp -B build \
+    && cmake --build build && cmake --install build \
+    && python3 ./setup.py bdist_wheel \
+    && python3 -m pip install dist/pulsar_client-*.whl --force-reinstall
+
+#
 # Add Python Packages
 #
-
-RUN apt-get update 
-RUN apt-get install -y --no-install-recommends apt-utils
-RUN apt-get update 
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y bzip2 zstd 
-# Stuff for pulsar 
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y default-jre protobuf-compiler python3-pybind11
-RUN apt-get clean
-RUN apt-get install python3-pip -y
-RUN python3 -m pip install --upgrade pip
-# Stuff for pulsar 
-RUN python3 -m pip install pulsar-client==2.10.2
 RUN pip install .
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -88,7 +88,7 @@ wipac-dev-tools[coloredlogs]==1.6.10
     # via
     #   skymap-scanner (setup.py)
     #   wipac-mqclient
-wipac-mqclient[pulsar]==0.6.7
+wipac-mqclient[pulsar]==0.6.8
     # via
     #   ewms-pilot
     #   skymap-scanner (setup.py)

--- a/skymap_scanner/recos/millipede_original.py
+++ b/skymap_scanner/recos/millipede_original.py
@@ -43,7 +43,7 @@ class MillipedeOriginal(RecoInterface):
     # At HESE energies, deposited light is dominated by the stochastic losses
     # (muon part emits so little light in comparison)
     # This is why we can use cascade tables
-    _splinedir = os.path.expandvars("$I3_TESTDATA/photospline")
+    _splinedir = os.path.expandvars("$I3_DATA/photon-tables/splines")
     _base = os.path.join(_splinedir, "ems_mie_z20_a10.%s.fits")
     for fname in [_base % "abs", _base % "prob"]:
         if not os.path.exists(fname):


### PR DESCRIPTION
Changes:
- manually compile pulsar in the docker image
- two-stage image build, using icetray-prod for the final image
- removed the download of the baseline_gcds - this is in the prod image
- removed the download of the extra spline tables - bind in yourself as needed