### PR TITLE
Replace `--startup-json-dir` with `--client-startup-json`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -117,7 +117,7 @@ jobs:
             --simulated-event \
             &
 
-          ./resources/launch_scripts/wait_for_file.sh ./startup.json CLIENT_STARTER_WAIT_FOR_STARTUP_JSON
+          ./resources/launch_scripts/wait_for_file.sh ./startup.json $CLIENT_STARTER_WAIT_FOR_STARTUP_JSON
 
           # Launch Clients
           nclients=$(( $CLIENTS_PER_CPU * $(nproc) ))
@@ -198,7 +198,7 @@ jobs:
             --real-event \
             &
 
-          ./resources/launch_scripts/wait_for_file.sh ./startup.json CLIENT_STARTER_WAIT_FOR_STARTUP_JSON
+          ./resources/launch_scripts/wait_for_file.sh ./startup.json $CLIENT_STARTER_WAIT_FOR_STARTUP_JSON
 
           # Launch Clients
           nclients=$(( $CLIENTS_PER_CPU * $(nproc) ))

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,7 +112,7 @@ jobs:
             --event-file $REALTIME_EVENTS_DIR/hese_event_01.json \
             --cache-dir $SKYSCAN_CACHE_DIR \
             --output-dir $SKYSCAN_OUTPUT_DIR \
-            --startup-json-file ./startup.json \
+            --client-startup-json ./startup.json \
             --nsides 1:12 \
             --simulated-event \
             &
@@ -127,7 +127,7 @@ jobs:
           for i in $( seq 1 $nclients ); do
             singularity run skymap_scanner.sif \
               python -m skymap_scanner.client \
-              --startup-json-file ./startup.json \
+              --client-startup-json ./startup.json \
               --debug-directory $SKYSCAN_DEBUG_DIR \
               &
             echo -e "\tclient #$i launched"
@@ -193,7 +193,7 @@ jobs:
             --event-file $REALTIME_EVENTS_DIR/${{ matrix.eventfile }} \
             --cache-dir $SKYSCAN_CACHE_DIR \
             --output-dir $SKYSCAN_OUTPUT_DIR \
-            --startup-json-file ./startup.json \
+            --client-startup-json ./startup.json \
             --nsides 1:12 \
             --real-event \
             &
@@ -207,7 +207,7 @@ jobs:
           export PULSAR_UNACKED_MESSAGES_TIMEOUT_SEC=1800  # 30 mins
           for i in $( seq 1 $nclients ); do
             ./resources/launch_scripts/docker/launch_client.sh \
-              --startup-json-file ./startup.json \
+              --client-startup-json ./startup.json \
               --debug-directory $SKYSCAN_DEBUG_DIR \
               &
             echo -e "\tclient #$i launched"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,12 +112,12 @@ jobs:
             --event-file $REALTIME_EVENTS_DIR/hese_event_01.json \
             --cache-dir $SKYSCAN_CACHE_DIR \
             --output-dir $SKYSCAN_OUTPUT_DIR \
-            --startup-json-dir . \
+            --startup-json-file ./startup.json \
             --nsides 1:12 \
             --simulated-event \
             &
 
-          ./resources/launch_scripts/wait_for_startup_json.sh .
+          ./resources/launch_scripts/wait_for_startup_json.sh ./startup.json
 
           # Launch Clients
           nclients=$(( $CLIENTS_PER_CPU * $(nproc) ))
@@ -127,7 +127,7 @@ jobs:
           for i in $( seq 1 $nclients ); do
             singularity run skymap_scanner.sif \
               python -m skymap_scanner.client \
-              --startup-json-dir . \
+              --startup-json-file ./startup.json \
               --debug-directory $SKYSCAN_DEBUG_DIR \
               &
             echo -e "\tclient #$i launched"
@@ -193,12 +193,12 @@ jobs:
             --event-file $REALTIME_EVENTS_DIR/${{ matrix.eventfile }} \
             --cache-dir $SKYSCAN_CACHE_DIR \
             --output-dir $SKYSCAN_OUTPUT_DIR \
-            --startup-json-dir . \
+            --startup-json-file ./startup.json \
             --nsides 1:12 \
             --real-event \
             &
 
-          ./resources/launch_scripts/wait_for_startup_json.sh .
+          ./resources/launch_scripts/wait_for_startup_json.sh ./startup.json
 
           # Launch Clients
           nclients=$(( $CLIENTS_PER_CPU * $(nproc) ))
@@ -207,7 +207,7 @@ jobs:
           export PULSAR_UNACKED_MESSAGES_TIMEOUT_SEC=1800  # 30 mins
           for i in $( seq 1 $nclients ); do
             ./resources/launch_scripts/docker/launch_client.sh \
-              --startup-json-dir . \
+              --startup-json-file ./startup.json \
               --debug-directory $SKYSCAN_DEBUG_DIR \
               &
             echo -e "\tclient #$i launched"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -117,7 +117,7 @@ jobs:
             --simulated-event \
             &
 
-          ./resources/launch_scripts/wait_for_startup_json.sh ./startup.json
+          ./resources/launch_scripts/wait_for_file.sh ./startup.json CLIENT_STARTER_WAIT_FOR_STARTUP_JSON
 
           # Launch Clients
           nclients=$(( $CLIENTS_PER_CPU * $(nproc) ))
@@ -198,7 +198,7 @@ jobs:
             --real-event \
             &
 
-          ./resources/launch_scripts/wait_for_startup_json.sh ./startup.json
+          ./resources/launch_scripts/wait_for_file.sh ./startup.json CLIENT_STARTER_WAIT_FOR_STARTUP_JSON
 
           # Launch Clients
           nclients=$(( $CLIENTS_PER_CPU * $(nproc) ))

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -68,7 +68,7 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
     - name: Python Semantic Release
-      uses: relekang/python-semantic-release@v7.28.1
+      uses: relekang/python-semantic-release@master
       with:
         github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         # repository_username: __token__

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ export SKYSCAN_BROKER_AUTH=$(cat ~/skyscan-broker.token)  # obfuscated for secur
 ```
 ###### Command-Line Arguments
 ```
-    --startup-json-file PATH_TO_STARTUP_JSON \
+    --client-startup-json PATH_TO_CLIENT_STARTUP_JSON \
     --cache-dir `pwd`/server_cache \
     --output-dir `pwd` \
     --reco-algo millipede \
@@ -69,8 +69,8 @@ export SKYSCAN_BROKER_AUTH=$(cat ~/skyscan-broker.token)  # obfuscated for secur
 ```
 _NOTE: The `--*dir` arguments can all be the same if you'd like. Relative paths are also fine._
 _NOTE: There are more CL arguments not shown. They have defaults._
-###### `startup.json`
-The server will create a `PATH_TO_STARTUP_JSON` file that has necessary info to launch a client. the parent directory of `--startup-json-file` needs to be somewhere accessible by your client launch script, whether that's via condor or manually.
+###### `client-startup.json`
+The server will create a `PATH_TO_CLIENT_STARTUP_JSON` file that has necessary info to launch a client. the parent directory of `--client-startup-json` needs to be somewhere accessible by your client launch script, whether that's via condor or manually.
 ##### Run It
 ###### with Singularity
 ```
@@ -91,7 +91,7 @@ export SKYSCAN_DOCKER_PULL_ALWAYS=0  # defaults to 1 which maps to '--pull=alway
 ```
 
 #### 2. Launch Each Client
-The client jobs can submitted via HTCondor from sub-2. Running the script below should create a condor submit file requesting the number of workers specified. You'll need to give it the same `SKYSCAN_BROKER_ADDRESS` and `BROKER_AUTH` as the server, and the path to the startup json file created by the server.
+The client jobs can submitted via HTCondor from sub-2. Running the script below should create a condor submit file requesting the number of workers specified. You'll need to give it the same `SKYSCAN_BROKER_ADDRESS` and `BROKER_AUTH` as the server, and the path to the client-startup json file created by the server.
 
 ##### Figure Your Args
 ###### Environment Variables
@@ -101,7 +101,7 @@ export SKYSCAN_BROKER_CLIENT=pulsar
 export SKYSCAN_BROKER_AUTH=$(cat ~/skyscan-broker.token)  # obfuscated for security
 ```
 ###### Command-Line Arguments
-_See notes about `--startup-json-file` below. See `client.py` for additional optional args._
+_See notes about `--client-startup-json` below. See `client.py` for additional optional args._
 ##### Run It
 ###### with Condor (via Singularity)
 You'll want to put your `skymap_scanner.client` args in a JSON file, then pass that to the helper script.
@@ -111,16 +111,16 @@ echo my_client_args.json  # just an example
     --jobs #### \
     --memory #GB \
     --singularity-image URL_OR_PATH_TO_SINGULARITY_IMAGE \
-    --startup-json-file PATH_TO_STARTUP_JSON \
+    --client-startup-json PATH_TO_CLIENT_STARTUP_JSON \
     --client-args-json my_client_args.json
 ```
-_NOTE: `client_starter.py` will wait until `--startup-json-file PATH_TO_STARTUP_JSON` exists, since it needs to file-transfer it to the worker node. Similarly, the client's `--startup-json-file` is auto-set by the script and thus, is disallowed from being in the `--client-args` arguments._
+_NOTE: `client_starter.py` will wait until `--client-startup-json PATH_TO_CLIENT_STARTUP_JSON` exists, since it needs to file-transfer it to the worker node. Similarly, the client's `--client-startup-json` is auto-set by the script and thus, is disallowed from being in the `--client-args` arguments._
 ###### or Manually (Docker)
 ```
 # side note: you may want to first set environment variables, see below
-./resources/launch_scripts/wait_for_startup_json.sh PATH_TO_STARTUP_JSON
+./resources/launch_scripts/wait_for_startup_json.sh PATH_TO_CLIENT_STARTUP_JSON
 ./resources/launch_scripts/docker/launch_client.sh \
-    --startup-json-file PATH_TO_STARTUP_JSON \
+    --client-startup-json PATH_TO_CLIENT_STARTUP_JSON \
     YOUR_ARGS
 ```
 _NOTE: By default the launch script will pull, build, and run the latest image from Docker Hub. You can optionally set environment variables to configure how to find a particular tag. For example:_
@@ -151,7 +151,7 @@ For now, it's easy to scale up using the command line. Multiple server instances
 export SKYSCAN_BROKER_ADDRESS=BROKER_ADDRESS
 export SKYSCAN_BROKER_CLIENT=pulsar
 export SKYSCAN_BROKER_AUTH=$(cat ~/skyscan-broker.token)  # obfuscated for security
-ls *.json | xargs -n1 -PN -I{} bash -c 'mkdir /path/to/json/{} && python -m skymap_scanner.server --startup-json-file /path/to/json/{}/startup.json --cache-dir /path/to/cache --output-dir /path/to/out --reco-algo RECO_ALGO --event-file /path/to/data/{}'
+ls *.json | xargs -n1 -PN -I{} bash -c 'mkdir /path/to/json/{} && python -m skymap_scanner.server --client-startup-json /path/to/json/{}/client-startup.json --cache-dir /path/to/cache --output-dir /path/to/out --reco-algo RECO_ALGO --event-file /path/to/data/{}'
 ```
 
 Then, from sub-2 run `ls *.json |xargs -I{} bash -c 'sed "s/UID/{}/g" ../condor > /scratch/$USER/{}.condor'` using the template condor submit file below. Then you should be able to just run:
@@ -160,7 +160,7 @@ ls /scratch/$USER/run*.condor | head -nN | xargs -I{} condor_submit {}
 ```
 ```
 executable = /bin/sh 
-arguments = /usr/local/icetray/env-shell.sh python -m skymap_scanner.client --startup-json-file ./startup.json
+arguments = /usr/local/icetray/env-shell.sh python -m skymap_scanner.client --client-startup-json ./client-startup.json
 +SingularityImage = "/cvmfs/icecube.opensciencegrid.org/containers/realtime/skymap_scanner:x.y.z"
 environment = "SKYSCAN_BROKER_AUTH=AUTHTOKEN SKYSCAN_BROKER_ADDRESS=BROKER_ADDRESS"
 Requirements = HAS_CVMFS_icecube_opensciencegrid_org && has_avx
@@ -169,7 +169,7 @@ error = /scratch/$USER/UID.err
 log = /scratch/$USER/UID.log
 +FileSystemDomain = "blah"
 should_transfer_files = YES
-transfer_input_files = /path/to/json/UID/startup.json 
+transfer_input_files = /path/to/json/UID/client-startup.json
 request_cpus = 1
 request_memory = 8GB
 notification = Error

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ _NOTE: `client_starter.py` will wait until `--client-startup-json PATH_TO_CLIENT
 ###### or Manually (Docker)
 ```
 # side note: you may want to first set environment variables, see below
-./resources/launch_scripts/wait_for_startup_json.sh PATH_TO_CLIENT_STARTUP_JSON
+./resources/launch_scripts/wait_for_file.sh PATH_TO_CLIENT_STARTUP_JSON 600
 ./resources/launch_scripts/docker/launch_client.sh \
     --client-startup-json PATH_TO_CLIENT_STARTUP_JSON \
     YOUR_ARGS

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ export SKYSCAN_BROKER_AUTH=$(cat ~/skyscan-broker.token)  # obfuscated for secur
 ```
 ###### Command-Line Arguments
 ```
-    --startup-json-dir DIR_TO_PUT_STARTUP_JSON \
+    --startup-json-file PATH_TO_STARTUP_JSON \
     --cache-dir `pwd`/server_cache \
     --output-dir `pwd` \
     --reco-algo millipede \
@@ -70,7 +70,7 @@ export SKYSCAN_BROKER_AUTH=$(cat ~/skyscan-broker.token)  # obfuscated for secur
 _NOTE: The `--*dir` arguments can all be the same if you'd like. Relative paths are also fine._
 _NOTE: There are more CL arguments not shown. They have defaults._
 ###### `startup.json`
-The server will create a `startup.json` file that has necessary info to launch a client. `--startup-json-dir` needs to be somewhere accessible by your client launch script, whether that's via condor or manually.
+The server will create a `PATH_TO_STARTUP_JSON` file that has necessary info to launch a client. the parent directory of `--startup-json-file` needs to be somewhere accessible by your client launch script, whether that's via condor or manually.
 ##### Run It
 ###### with Singularity
 ```
@@ -101,7 +101,7 @@ export SKYSCAN_BROKER_CLIENT=pulsar
 export SKYSCAN_BROKER_AUTH=$(cat ~/skyscan-broker.token)  # obfuscated for security
 ```
 ###### Command-Line Arguments
-_See notes about '--startup-json'/--startup-json-dir' below. See client.py for additional optional args._
+_See notes about `--startup-json-file` below. See `client.py` for additional optional args._
 ##### Run It
 ###### with Condor (via Singularity)
 You'll want to put your `skymap_scanner.client` args in a JSON file, then pass that to the helper script.
@@ -111,16 +111,16 @@ echo my_client_args.json  # just an example
     --jobs #### \
     --memory #GB \
     --singularity-image URL_OR_PATH_TO_SINGULARITY_IMAGE \
-    --startup-json PATH_TO_STARTUP_JSON \
+    --startup-json-file PATH_TO_STARTUP_JSON \
     --client-args-json my_client_args.json
 ```
-_NOTE: `client_starter.py` will wait until `--startup-json PATH_TO_STARTUP_JSON` exists, since it needs to file-transfer it to the worker node. Similarly, `--startup-json-dir` is auto-set by the script and thus, is disallowed from being in the `--client-args-json` file._
+_NOTE: `client_starter.py` will wait until `--startup-json-file PATH_TO_STARTUP_JSON` exists, since it needs to file-transfer it to the worker node. Similarly, the client's `--startup-json-file` is auto-set by the script and thus, is disallowed from being in the `--client-args` arguments._
 ###### or Manually (Docker)
 ```
 # side note: you may want to first set environment variables, see below
-./resources/launch_scripts/wait_for_startup_json.sh DIR_WITH_STARTUP_JSON
+./resources/launch_scripts/wait_for_startup_json.sh PATH_TO_STARTUP_JSON
 ./resources/launch_scripts/docker/launch_client.sh \
-    --startup-json-dir DIR_WITH_STARTUP_JSON \
+    --startup-json-file PATH_TO_STARTUP_JSON \
     YOUR_ARGS
 ```
 _NOTE: By default the launch script will pull, build, and run the latest image from Docker Hub. You can optionally set environment variables to configure how to find a particular tag. For example:_
@@ -151,7 +151,7 @@ For now, it's easy to scale up using the command line. Multiple server instances
 export SKYSCAN_BROKER_ADDRESS=BROKER_ADDRESS
 export SKYSCAN_BROKER_CLIENT=pulsar
 export SKYSCAN_BROKER_AUTH=$(cat ~/skyscan-broker.token)  # obfuscated for security
-ls *.json | xargs -n1 -PN -I{} bash -c 'mkdir /path/to/json/{} && python -m skymap_scanner.server --startup-json-dir /path/to/json/{} --cache-dir /path/to/cache --output-dir /path/to/out --reco-algo RECO_ALGO --event-file /path/to/data/{}'
+ls *.json | xargs -n1 -PN -I{} bash -c 'mkdir /path/to/json/{} && python -m skymap_scanner.server --startup-json-file /path/to/json/{}/startup.json --cache-dir /path/to/cache --output-dir /path/to/out --reco-algo RECO_ALGO --event-file /path/to/data/{}'
 ```
 
 Then, from sub-2 run `ls *.json |xargs -I{} bash -c 'sed "s/UID/{}/g" ../condor > /scratch/$USER/{}.condor'` using the template condor submit file below. Then you should be able to just run:
@@ -160,7 +160,7 @@ ls /scratch/$USER/run*.condor | head -nN | xargs -I{} condor_submit {}
 ```
 ```
 executable = /bin/sh 
-arguments = /usr/local/icetray/env-shell.sh python -m skymap_scanner.client --startup-json-dir .
+arguments = /usr/local/icetray/env-shell.sh python -m skymap_scanner.client --startup-json-file ./startup.json
 +SingularityImage = "/cvmfs/icecube.opensciencegrid.org/containers/realtime/skymap_scanner:x.y.z"
 environment = "SKYSCAN_BROKER_AUTH=AUTHTOKEN SKYSCAN_BROKER_ADDRESS=BROKER_ADDRESS"
 Requirements = HAS_CVMFS_icecube_opensciencegrid_org && has_avx

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -28,7 +28,7 @@ coloredlogs==15.0.1
     # via wipac-dev-tools
 contourpy==1.0.7
     # via matplotlib
-cryptography==39.0.0
+cryptography==39.0.1
     # via pyjwt
 cycler==0.11.0
     # via matplotlib
@@ -46,7 +46,7 @@ google-auth==2.16.0
     # via
     #   google-api-core
     #   wipac-mqclient
-google-cloud-pubsub==2.14.0
+google-cloud-pubsub==2.14.1
     # via wipac-mqclient
 googleapis-common-protos[grpc]==1.58.0
     # via
@@ -56,14 +56,14 @@ googleapis-common-protos[grpc]==1.58.0
     #   wipac-mqclient
 grpc-google-iam-v1==0.12.6
     # via google-cloud-pubsub
-grpcio==1.52.0
+grpcio==1.51.1
     # via
     #   google-api-core
     #   google-cloud-pubsub
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.52.0
+grpcio-status==1.51.1
     # via
     #   google-api-core
     #   google-cloud-pubsub

--- a/requirements-client-starter.txt
+++ b/requirements-client-starter.txt
@@ -24,7 +24,7 @@ coloredlogs==15.0.1
     # via wipac-dev-tools
 contourpy==1.0.7
     # via matplotlib
-cryptography==39.0.0
+cryptography==39.0.1
     # via pyjwt
 cycler==0.11.0
     # via matplotlib

--- a/requirements-gcp.txt
+++ b/requirements-gcp.txt
@@ -26,7 +26,7 @@ coloredlogs==15.0.1
     # via wipac-dev-tools
 contourpy==1.0.7
     # via matplotlib
-cryptography==39.0.0
+cryptography==39.0.1
     # via pyjwt
 cycler==0.11.0
     # via matplotlib
@@ -42,7 +42,7 @@ google-auth==2.16.0
     # via
     #   google-api-core
     #   wipac-mqclient
-google-cloud-pubsub==2.14.0
+google-cloud-pubsub==2.14.1
     # via wipac-mqclient
 googleapis-common-protos[grpc]==1.58.0
     # via
@@ -52,14 +52,14 @@ googleapis-common-protos[grpc]==1.58.0
     #   wipac-mqclient
 grpc-google-iam-v1==0.12.6
     # via google-cloud-pubsub
-grpcio==1.52.0
+grpcio==1.51.1
     # via
     #   google-api-core
     #   google-cloud-pubsub
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.52.0
+grpcio-status==1.51.1
     # via
     #   google-api-core
     #   google-cloud-pubsub

--- a/requirements-nats.txt
+++ b/requirements-nats.txt
@@ -24,7 +24,7 @@ coloredlogs==15.0.1
     # via wipac-dev-tools
 contourpy==1.0.7
     # via matplotlib
-cryptography==39.0.0
+cryptography==39.0.1
     # via pyjwt
 cycler==0.11.0
     # via matplotlib

--- a/requirements-pulsar.txt
+++ b/requirements-pulsar.txt
@@ -26,7 +26,7 @@ coloredlogs==15.0.1
     # via wipac-dev-tools
 contourpy==1.0.7
     # via matplotlib
-cryptography==39.0.0
+cryptography==39.0.1
     # via pyjwt
 cycler==0.11.0
     # via matplotlib

--- a/requirements-rabbitmq.txt
+++ b/requirements-rabbitmq.txt
@@ -24,7 +24,7 @@ coloredlogs==15.0.1
     # via wipac-dev-tools
 contourpy==1.0.7
     # via matplotlib
-cryptography==39.0.0
+cryptography==39.0.1
     # via pyjwt
 cycler==0.11.0
     # via matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ coloredlogs==15.0.1
     # via wipac-dev-tools
 contourpy==1.0.7
     # via matplotlib
-cryptography==39.0.0
+cryptography==39.0.1
     # via pyjwt
 cycler==0.11.0
     # via matplotlib

--- a/resources/client_starter.py
+++ b/resources/client_starter.py
@@ -50,11 +50,11 @@ def make_condor_job_description(  # pylint: disable=too-many-arguments
     accounting_group: str,
     # skymap scanner args
     singularity_image: str,
-    startup_json_file: Path,
+    client_startup_json: Path,
     client_args: str,
 ) -> htcondor.Submit:
     """Make the condor job description object."""
-    transfer_input_files: List[Path] = [startup_json_file]
+    transfer_input_files: List[Path] = [client_startup_json]
 
     # NOTE:
     # In the newest version of condor we could use:
@@ -72,7 +72,7 @@ def make_condor_job_description(  # pylint: disable=too-many-arguments
     # write
     submit_dict = {
         "executable": "/bin/sh",
-        "arguments": f"/usr/local/icetray/env-shell.sh python -m skymap_scanner.client {client_args} --startup-json-file ./{startup_json_file.name}",
+        "arguments": f"/usr/local/icetray/env-shell.sh python -m skymap_scanner.client {client_args} --client-startup-json ./{client_startup_json.name}",
         "+SingularityImage": singularity_image,
         "getenv": "SKYSCAN_*, EWMS_*, PULSAR_UNACKED_MESSAGES_TIMEOUT_SEC",
         "output": str(logs_subdir / "client-$(ProcId).out"),
@@ -217,7 +217,7 @@ def main() -> None:
         help="a path or url to the singularity image",
     )
     parser.add_argument(
-        "--startup-json-file",
+        "--client-startup-json",
         help="The 'startup.json' file to startup each client",
         type=lambda x: wait_for_file(
             Path(x), int(os.getenv("CLIENT_STARTER_WAIT_FOR_STARTUP_JSON", "60"))
@@ -250,10 +250,10 @@ def main() -> None:
         carg, value = carg_value.split(":", maxsplit=1)
         client_args += f" --{carg} {value} "
     LOGGER.info(f"Client Args: {client_args}")
-    if "--startup-json-file" in client_args:
+    if "--client-startup-json" in client_args:
         raise RuntimeError(
-            "The '--client-args' arg cannot include \"--startup-json-file\". "
-            "This needs to be given to this script explicitly ('--startup-json-file')."
+            "The '--client-args' arg cannot include \"--client-startup-json\". "
+            "This needs to be given to this script explicitly ('--client-startup-json')."
         )
 
     # make condor job description
@@ -264,7 +264,7 @@ def main() -> None:
         args.accounting_group,
         # skymap scanner args
         args.singularity_image,
-        args.startup_json_file,
+        args.client_startup_json,
         client_args,
     )
     LOGGER.info(job_description)

--- a/resources/client_starter.py
+++ b/resources/client_starter.py
@@ -50,11 +50,11 @@ def make_condor_job_description(  # pylint: disable=too-many-arguments
     accounting_group: str,
     # skymap scanner args
     singularity_image: str,
-    startup_json: Path,
+    startup_json_file: Path,
     client_args: str,
 ) -> htcondor.Submit:
     """Make the condor job description object."""
-    transfer_input_files: List[str] = [str(startup_json)]
+    transfer_input_files: List[Path] = [startup_json_file]
 
     # NOTE:
     # In the newest version of condor we could use:
@@ -72,7 +72,7 @@ def make_condor_job_description(  # pylint: disable=too-many-arguments
     # write
     submit_dict = {
         "executable": "/bin/sh",
-        "arguments": f"/usr/local/icetray/env-shell.sh python -m skymap_scanner.client {client_args} --startup-json-dir .",
+        "arguments": f"/usr/local/icetray/env-shell.sh python -m skymap_scanner.client {client_args} --startup-json-file ./{startup_json_file.name}",
         "+SingularityImage": singularity_image,
         "getenv": "SKYSCAN_*, EWMS_*, PULSAR_UNACKED_MESSAGES_TIMEOUT_SEC",
         "output": str(logs_subdir / "client-$(ProcId).out"),
@@ -81,7 +81,7 @@ def make_condor_job_description(  # pylint: disable=too-many-arguments
         "+FileSystemDomain": "blah",
         "should_transfer_files": "YES",
         "transfer_input_files": ",".join(
-            [os.path.abspath(f) for f in transfer_input_files]
+            [os.path.abspath(str(f)) for f in transfer_input_files]
         ),
         "request_cpus": "1",
         "request_memory": memory,
@@ -217,7 +217,7 @@ def main() -> None:
         help="a path or url to the singularity image",
     )
     parser.add_argument(
-        "--startup-json",
+        "--startup-json-file",
         help="The 'startup.json' file to startup each client",
         type=lambda x: wait_for_file(
             Path(x), int(os.getenv("CLIENT_STARTER_WAIT_FOR_STARTUP_JSON", "60"))
@@ -250,10 +250,10 @@ def main() -> None:
         carg, value = carg_value.split(":", maxsplit=1)
         client_args += f" --{carg} {value} "
     LOGGER.info(f"Client Args: {client_args}")
-    if "--startup-json-dir" in client_args:
+    if "--startup-json-file" in client_args:
         raise RuntimeError(
-            "The '--client-args' file cannot include \"--startup-json-dir\". "
-            "This needs to be defined explicitly with '--startup-json'."
+            "The '--client-args' arg cannot include \"--startup-json-file\". "
+            "This needs to be given to this script explicitly ('--startup-json-file')."
         )
 
     # make condor job description
@@ -264,7 +264,7 @@ def main() -> None:
         args.accounting_group,
         # skymap scanner args
         args.singularity_image,
-        args.startup_json,
+        args.startup_json_file,
         client_args,
     )
     LOGGER.info(job_description)

--- a/resources/launch_scripts/docker/launch_client.sh
+++ b/resources/launch_scripts/docker/launch_client.sh
@@ -32,7 +32,7 @@ def extract_opt_path(py_args, opt):
 
 py_args, debug_dir = extract_opt_path(py_args, "--debug-directory")
 py_args, gcd = extract_opt_path(py_args, "--gcd-dir")
-py_args, startup = extract_opt_path(py_args, "--startup-json-dir")
+py_args, startup = extract_opt_path(py_args, "--startup-json-file")
 
 dockermount_args = ""
 py_args += " "
@@ -46,8 +46,8 @@ if gcd:
     # NOTE: WE ARE NOT FORWARDING THIS ARG TO THE SCRIPT B/C ITS PASSED WITHIN THE STARTUP.JSON
     #
 if startup:
-    dockermount_args += f"--mount type=bind,source={startup},target=/local/startup-json-dir "
-    py_args += f"--startup-json-dir /local/startup-json-dir "
+    dockermount_args += f"--mount type=bind,source={os.path.dirname(startup)},target=/local/startup "
+    py_args += f"--startup-json-file /local/startup/os.path.basename(startup) "
 
 print(f"{dockermount_args}#{py_args}")
 ')

--- a/resources/launch_scripts/docker/launch_client.sh
+++ b/resources/launch_scripts/docker/launch_client.sh
@@ -47,7 +47,7 @@ if gcd:
     #
 if startup:
     dockermount_args += f"--mount type=bind,source={os.path.dirname(startup)},target=/local/startup "
-    py_args += f"--startup-json-file /local/startup/os.path.basename(startup) "
+    py_args += f"--startup-json-file /local/startup/{os.path.basename(startup)} "
 
 print(f"{dockermount_args}#{py_args}")
 ')

--- a/resources/launch_scripts/docker/launch_client.sh
+++ b/resources/launch_scripts/docker/launch_client.sh
@@ -32,7 +32,7 @@ def extract_opt_path(py_args, opt):
 
 py_args, debug_dir = extract_opt_path(py_args, "--debug-directory")
 py_args, gcd = extract_opt_path(py_args, "--gcd-dir")
-py_args, startup = extract_opt_path(py_args, "--startup-json-file")
+py_args, startup = extract_opt_path(py_args, "--client-startup-json")
 
 dockermount_args = ""
 py_args += " "
@@ -47,7 +47,7 @@ if gcd:
     #
 if startup:
     dockermount_args += f"--mount type=bind,source={os.path.dirname(startup)},target=/local/startup "
-    py_args += f"--startup-json-file /local/startup/{os.path.basename(startup)} "
+    py_args += f"--client-startup-json /local/startup/{os.path.basename(startup)} "
 
 print(f"{dockermount_args}#{py_args}")
 ')

--- a/resources/launch_scripts/docker/launch_server.sh
+++ b/resources/launch_scripts/docker/launch_server.sh
@@ -34,7 +34,7 @@ py_args, event = extract_opt_path(py_args, "--event-file")
 py_args, cache = extract_opt_path(py_args, "--cache-dir")
 py_args, output = extract_opt_path(py_args, "--output-dir")
 py_args, gcd = extract_opt_path(py_args, "--gcd-dir")
-py_args, startup = extract_opt_path(py_args, "--startup-json-file")
+py_args, startup = extract_opt_path(py_args, "--client-startup-json")
 
 dockermount_args = ""
 py_args += " "
@@ -53,7 +53,7 @@ if gcd:
     py_args += f"--gcd-dir /local/gcd "
 if startup:
     dockermount_args += f"--mount type=bind,source={os.path.dirname(startup)},target=/local/startup "
-    py_args += f"--startup-json-file /local/startup/{os.path.basename(startup)} "
+    py_args += f"--client-startup-json /local/startup/{os.path.basename(startup)} "
 
 print(f"{dockermount_args}#{py_args}")
 ')

--- a/resources/launch_scripts/docker/launch_server.sh
+++ b/resources/launch_scripts/docker/launch_server.sh
@@ -53,7 +53,7 @@ if gcd:
     py_args += f"--gcd-dir /local/gcd "
 if startup:
     dockermount_args += f"--mount type=bind,source={os.path.dirname(startup)},target=/local/startup "
-    py_args += f"--startup-json-file /local/startup/os.path.basename(startup) "
+    py_args += f"--startup-json-file /local/startup/{os.path.basename(startup)} "
 
 print(f"{dockermount_args}#{py_args}")
 ')

--- a/resources/launch_scripts/docker/launch_server.sh
+++ b/resources/launch_scripts/docker/launch_server.sh
@@ -34,7 +34,7 @@ py_args, event = extract_opt_path(py_args, "--event-file")
 py_args, cache = extract_opt_path(py_args, "--cache-dir")
 py_args, output = extract_opt_path(py_args, "--output-dir")
 py_args, gcd = extract_opt_path(py_args, "--gcd-dir")
-py_args, startup = extract_opt_path(py_args, "--startup-json-dir")
+py_args, startup = extract_opt_path(py_args, "--startup-json-file")
 
 dockermount_args = ""
 py_args += " "
@@ -52,8 +52,8 @@ if gcd:
     dockermount_args += f"--mount type=bind,source={gcd},target=/local/gcd,readonly "
     py_args += f"--gcd-dir /local/gcd "
 if startup:
-    dockermount_args += f"--mount type=bind,source={startup},target=/local/startup-json-dir "
-    py_args += f"--startup-json-dir /local/startup-json-dir "
+    dockermount_args += f"--mount type=bind,source={os.path.dirname(startup)},target=/local/startup "
+    py_args += f"--startup-json-file /local/startup/os.path.basename(startup) "
 
 print(f"{dockermount_args}#{py_args}")
 ')

--- a/resources/launch_scripts/wait_for_file.sh
+++ b/resources/launch_scripts/wait_for_file.sh
@@ -17,6 +17,10 @@ if [ ! -d $(dirname $1) ]; then
     echo "Directory Not Found: $(dirname $1)"
     exit 2
 fi
+if [[ "$2" != +([[:digit:]]) ]]; then
+    echo "Wait duration must be a number (seconds): $2"
+    exit 2
+fi
 
 waitsec="5"
 timeout="$2"

--- a/resources/launch_scripts/wait_for_file.sh
+++ b/resources/launch_scripts/wait_for_file.sh
@@ -5,16 +5,12 @@
 # Wait for $1 after launching a Skymap Scanner server
 # and before launching any clients
 #
-# Pass in one argument, the filepath to the file
+# Pass in two arguments, the filepath to the file & wait duration
 #
 ########################################################################
 
-waitsec="5"
-timeout=${CLIENT_STARTER_WAIT_FOR_STARTUP_JSON:-"600"}
-echo "Will wait for '$1' for $timeout seconds in $waitsec second intervals"
-
-if [ -z "$1" ]; then
-    echo "Usage: wait_for_startup_json.sh STARTUP_JSON_FILE"
+if [ -z "$1" ] || [ -z "$2" ]; then
+    echo "Usage: wait_for_file.sh FILE DURATION_SECONDS"
     exit 1
 fi
 if [ ! -d $(dirname $1) ]; then
@@ -22,8 +18,12 @@ if [ ! -d $(dirname $1) ]; then
     exit 2
 fi
 
-# wait until the startup-json file exists (with a timeout)
-endtime=$(date -ud "$timeout seconds" +%s)  # wait this long for server startup
+waitsec="5"
+timeout="$2"
+echo "Will wait for '$1' for $timeout seconds in $waitsec second intervals"
+
+# wait until the file exists (with a timeout)
+endtime=$(date -ud "$timeout seconds" +%s)  # wait this long
 while [[ $(date -u +%s) -le $endtime ]]; do
     if [[ -e "$1" ]]; then
         echo "Success! '$1' file found:"

--- a/resources/launch_scripts/wait_for_startup_json.sh
+++ b/resources/launch_scripts/wait_for_startup_json.sh
@@ -2,38 +2,38 @@
 
 ########################################################################
 #
-# Wait for startup.json after launching a Skymap Scanner server
+# Wait for $1 after launching a Skymap Scanner server
 # and before launching any clients
 #
-# Pass in one argument, the directory that will contain the startup.json
+# Pass in one argument, the filepath to the file
 #
 ########################################################################
 
 waitsec="5"
 timeout=${CLIENT_STARTER_WAIT_FOR_STARTUP_JSON:-"600"}
-echo "Will wait for startup.json for $timeout seconds in $waitsec second intervals"
+echo "Will wait for '$1' for $timeout seconds in $waitsec second intervals"
 
 if [ -z "$1" ]; then
-    echo "Usage: wait_for_startup_json.sh STARTUP_DIRECTORY"
+    echo "Usage: wait_for_startup_json.sh STARTUP_JSON_FILE"
     exit 1
 fi
-if [ ! -d "$1" ]; then
-    echo "Directory Not Found: $1"
+if [ ! -d $(dirname $1) ]; then
+    echo "Directory Not Found: $(dirname $1)"
     exit 2
 fi
 
-# wait until the startup.json file exists (with a timeout)
+# wait until the startup-json file exists (with a timeout)
 endtime=$(date -ud "$timeout seconds" +%s)  # wait this long for server startup
 while [[ $(date -u +%s) -le $endtime ]]; do
-    if [[ -e "$1/startup.json" ]]; then
-        echo "Success! 'startup.json' file found:"
+    if [[ -e "$1" ]]; then
+        echo "Success! '$1' file found:"
         ls $1
         exit 0  # Done!
     fi
-    echo "waiting for 'startup.json' ($waitsec second intervals)..."
+    echo "waiting for '$1' ($waitsec second intervals)..."
     sleep $waitsec
 done
 
-echo "Failed. 'startup.json' not found within time limit ($timeout seconds):"
+echo "Failed. '$1' not found within time limit ($timeout seconds):"
 ls $1
 exit 62  # Timer expired

--- a/skymap_scanner/client/client.py
+++ b/skymap_scanner/client/client.py
@@ -27,7 +27,7 @@ def main() -> None:
 
     # startup.json
     parser.add_argument(
-        "--startup-json-file",
+        "--client-startup-json",
         help=(
             "The filepath to the JSON file to startup the client "
             "(has keys 'mq_basename', 'baseline_GCD_file', and 'GCDQp_packet')"
@@ -59,7 +59,7 @@ def main() -> None:
     logging_tools.log_argparse_args(args, logger=LOGGER, level="WARNING")
 
     # read startup.json
-    with open(args.startup_json_file, "rb") as f:
+    with open(args.client_startup_json, "rb") as f:
         startup_json_dict = json.load(f)
     with open("GCDQp_packet.json", "w") as f:
         json.dump(startup_json_dict["GCDQp_packet"], f)

--- a/skymap_scanner/client/client.py
+++ b/skymap_scanner/client/client.py
@@ -27,15 +27,15 @@ def main() -> None:
 
     # startup.json
     parser.add_argument(
-        "--startup-json-dir",
+        "--startup-json-file",
         help=(
-            "The directory with the 'startup.json' file to startup the client "
+            "The filepath to the JSON file to startup the client "
             "(has keys 'mq_basename', 'baseline_GCD_file', and 'GCDQp_packet')"
         ),
         type=lambda x: argparse_tools.validate_arg(
             Path(x),
-            Path(x).is_dir(),
-            NotADirectoryError(x),
+            Path(x).parent.is_dir(),
+            NotADirectoryError(Path(x).parent),
         ),
     )
 
@@ -59,7 +59,7 @@ def main() -> None:
     logging_tools.log_argparse_args(args, logger=LOGGER, level="WARNING")
 
     # read startup.json
-    with open(args.startup_json_dir / "startup.json", "rb") as f:
+    with open(args.startup_json_file, "rb") as f:
         startup_json_dict = json.load(f)
     with open("GCDQp_packet.json", "w") as f:
         json.dump(startup_json_dict["GCDQp_packet"], f)

--- a/skymap_scanner/server/start_scan.py
+++ b/skymap_scanner/server/start_scan.py
@@ -927,7 +927,7 @@ async def serve_scan_iteration(
 
 
 def write_startup_json(
-    startup_json_file: Path,
+    client_startup_json: Path,
     event_metadata: EventMetadata,
     min_nside: int,  # TODO: replace with nsides & implement (https://github.com/icecube/skymap_scanner/issues/79)
     max_nside: int,  # TODO: remove (https://github.com/icecube/skymap_scanner/issues/79)
@@ -956,10 +956,10 @@ def write_startup_json(
         ),
     }
 
-    with open(startup_json_file, "w") as f:
+    with open(client_startup_json, "w") as f:
         json.dump(json_dict, f)
     LOGGER.info(
-        f"Startup JSON: {startup_json_file} ({startup_json_file.stat().st_size} bytes)"
+        f"Startup JSON: {client_startup_json} ({client_startup_json.stat().st_size} bytes)"
     )
 
     return json_dict["scan_id"]  # type: ignore[no-any-return]
@@ -986,7 +986,7 @@ def main() -> None:
 
     # directory args
     parser.add_argument(
-        "--startup-json-file",
+        "--client-startup-json",
         required=True,
         help="The filepath to save the JSON needed to spawn clients (the parent directory must already exist)",
         type=lambda x: argparse_tools.validate_arg(
@@ -1132,7 +1132,7 @@ def main() -> None:
 
     # write startup files for client-spawning
     scan_id = write_startup_json(
-        args.startup_json_file,
+        args.client_startup_json,
         event_metadata,
         min_nside,  # TODO: replace with args.nsides & implement (https://github.com/icecube/skymap_scanner/issues/79)
         max_nside,  # TODO: remove (https://github.com/icecube/skymap_scanner/issues/79)


### PR DESCRIPTION
This simplifies the relationship between the client starter and the scanner. 

For manual running: This change also allows for uniquely named startup-json files without the need for uniquely-named parent directories.