### PR TITLE
Re-enable Full CI On `main`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,8 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # don't cancel on main/master/default
+  cancel-in-progress: format('refs/heads/{0}', github.event.repository.default_branch) != github.ref
 
 env:
   PY_COLORS: "1"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   # don't cancel on main/master/default
-  cancel-in-progress: format('refs/heads/{0}', github.event.repository.default_branch) != github.ref
+  cancel-in-progress: ${{ format('refs/heads/{0}', github.event.repository.default_branch) != github.ref }}
 
 env:
   PY_COLORS: "1"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -331,4 +331,3 @@ jobs:
             --disqualify-zero-energy-pixels \
             --assert \
             || (cat $(ls tests/data/reco_pixel_pkls/${{ matrix.dir }}/*.diff.json) && false)
-

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -58,7 +58,8 @@ jobs:
           pip install .
 
   release:
-    if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
+    # only run on main/master/default
+    if: format('refs/heads/{0}', github.event.repository.default_branch) == github.ref
     needs: [py-setup, pip-install]
     runs-on: ubuntu-latest
     concurrency: release


### PR DESCRIPTION
Currently, the CI workflow using `concurrency` causes good merges to show an :x: when there should otherwise be a :heavy_check_mark:. This update allows the full CI workflow to proceed on `main` merges. Nothing is changed in the workflow for branches.

Side note: This is where a :no_entry_sign: would be useful... someday GitHub...