### PR TITLE
Fix `htcondor` Pip Install for Docker Builds

### DIFF
--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -55,7 +55,7 @@ jobs:
           python-version: ${{ matrix.py3 }}
       - run: |
           pip install --upgrade pip wheel setuptools
-          pip install .
+          pip install .[all,client-starter]
 
   release:
     # only run on main/master/default

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,8 @@ FROM icecube/icetray:icetray-prod-$ICETRAY_VERSION as prod
 #
 WORKDIR /local
 COPY . .
-RUN pip install .[rabbitmq,client-starter]
+# client-starter fails to install on architectures not supporting htcondor, so silently fail without the extra
+RUN pip install .[client-starter,rabbitmq] || pip install .[rabbitmq]
 
 
 # set the entry point so that module is called with any parameters given to the `docker run` command


### PR DESCRIPTION
ARM does not support htcondor, which means we cannot install the `client-starter` extra. That's fine for a majority of scenarios, we will just need to be careful where/how we run the client starter. Additional updates/redesign for production may be needed.