### PR TITLE
Use parallel processing

### DIFF
--- a/skymap_scanner/recos/__init__.py
+++ b/skymap_scanner/recos/__init__.py
@@ -51,7 +51,9 @@ def get_reco_interface_object(name: str) -> RecoInterface:
     """Dynamically import the reco sub-module's class."""
     try:
         module = importlib.import_module(f"{__name__}.{name.lower()}")
-        return getattr(module, ''.join(x.capitalize() for x in name.split('_')))
+        reco_class = getattr(module, ''.join(x.capitalize() for x in name.split('_')))
+        reco_class.name = name
+        return reco_class
     except ModuleNotFoundError as e:
         if name not in get_all_reco_algos():
             # checking this in 'except' allows us to use 'from e'

--- a/skymap_scanner/utils/pixelreco.py
+++ b/skymap_scanner/utils/pixelreco.py
@@ -46,10 +46,10 @@ class PixelReco:
     def from_i3frame(
         frame: I3Frame,
         geometry: I3Frame,
-        reco_algo: str,
+        reco_obj: recos.RecoInterface,
     ) -> "PixelReco":
         """Get a PixelReco instance by parsing the I3Frame."""
-        return recos.get_reco_interface_object(reco_algo).to_pixelreco(frame, geometry)
+        return reco_obj.to_pixelreco(frame, geometry)
 
 
 NSidesDict = Dict[int, Dict[int, PixelReco]]


### PR DESCRIPTION
This changes the server to send a list of several p-frames to the clients.
The clients process the frames in parallel using python's multiprocessing
module. The tables used by photospline are shared between the processes.
The number of parallel trays can be controlled with the new option --parallel-trays
