### PR TITLE
Fix CI for Bots on `main`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,8 @@ name: tests
 on:
   push:
     branches-ignore:
-      - '${{ github.event.repository.default_branch }}'
+      - master
+      - main
     tags:
       - '**'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: tests
 on:
   push:
     branches-ignore:
-      - ${{ github.event.repository.default_branch }}
+      - '${{ github.event.repository.default_branch }}'
     tags:
       - '**'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: tests
 
 on:
   push:
-    branches:
-      - '**'
-    tags-ignore:
+    branches-ignore:
+      - ${{ github.event.repository.default_branch }}
+    tags:
       - '**'
 
 concurrency:

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -21,6 +21,8 @@ jobs:
   #     - uses: WIPACrepo/wipac-dev-mypy-action@v1.1
 
   py-setup:
+    # don't run on main/master/default
+    if: format('refs/heads/{0}', github.event.repository.default_branch) != github.ref
     runs-on: ubuntu-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -21,8 +21,6 @@ jobs:
   #     - uses: WIPACrepo/wipac-dev-mypy-action@v1.1
 
   py-setup:
-    # don't run on main/master/default
-    if: format('refs/heads/{0}', github.event.repository.default_branch) != github.ref
     runs-on: ubuntu-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -26,7 +26,7 @@ coloredlogs==15.0.1
     # via wipac-dev-tools
 contourpy==1.0.7
     # via matplotlib
-cryptography==39.0.1
+cryptography==39.0.2
     # via pyjwt
 cycler==0.11.0
     # via matplotlib
@@ -179,5 +179,5 @@ wipac-dev-tools[coloredlogs]==1.6.12
     #   oms-mqclient
     #   skymap-scanner (setup.py)
     #   wipac-rest-tools
-wipac-rest-tools==1.4.13
+wipac-rest-tools==1.4.14
     # via skymap-scanner (setup.py)

--- a/requirements-client-starter.txt
+++ b/requirements-client-starter.txt
@@ -22,7 +22,7 @@ coloredlogs==15.0.1
     # via wipac-dev-tools
 contourpy==1.0.7
     # via matplotlib
-cryptography==39.0.1
+cryptography==39.0.2
     # via pyjwt
 cycler==0.11.0
     # via matplotlib
@@ -117,5 +117,5 @@ wipac-dev-tools[coloredlogs]==1.6.12
     #   oms-mqclient
     #   skymap-scanner (setup.py)
     #   wipac-rest-tools
-wipac-rest-tools==1.4.13
+wipac-rest-tools==1.4.14
     # via skymap-scanner (setup.py)

--- a/requirements-gcp.txt
+++ b/requirements-gcp.txt
@@ -24,7 +24,7 @@ coloredlogs==15.0.1
     # via wipac-dev-tools
 contourpy==1.0.7
     # via matplotlib
-cryptography==39.0.1
+cryptography==39.0.2
     # via pyjwt
 cycler==0.11.0
     # via matplotlib
@@ -167,5 +167,5 @@ wipac-dev-tools[coloredlogs]==1.6.12
     #   oms-mqclient
     #   skymap-scanner (setup.py)
     #   wipac-rest-tools
-wipac-rest-tools==1.4.13
+wipac-rest-tools==1.4.14
     # via skymap-scanner (setup.py)

--- a/requirements-nats.txt
+++ b/requirements-nats.txt
@@ -22,7 +22,7 @@ coloredlogs==15.0.1
     # via wipac-dev-tools
 contourpy==1.0.7
     # via matplotlib
-cryptography==39.0.1
+cryptography==39.0.2
     # via pyjwt
 cycler==0.11.0
     # via matplotlib
@@ -121,5 +121,5 @@ wipac-dev-tools[coloredlogs]==1.6.12
     #   oms-mqclient
     #   skymap-scanner (setup.py)
     #   wipac-rest-tools
-wipac-rest-tools==1.4.13
+wipac-rest-tools==1.4.14
     # via skymap-scanner (setup.py)

--- a/requirements-pulsar.txt
+++ b/requirements-pulsar.txt
@@ -24,7 +24,7 @@ coloredlogs==15.0.1
     # via wipac-dev-tools
 contourpy==1.0.7
     # via matplotlib
-cryptography==39.0.1
+cryptography==39.0.2
     # via pyjwt
 cycler==0.11.0
     # via matplotlib
@@ -119,5 +119,5 @@ wipac-dev-tools[coloredlogs]==1.6.12
     #   oms-mqclient
     #   skymap-scanner (setup.py)
     #   wipac-rest-tools
-wipac-rest-tools==1.4.13
+wipac-rest-tools==1.4.14
     # via skymap-scanner (setup.py)

--- a/requirements-rabbitmq.txt
+++ b/requirements-rabbitmq.txt
@@ -22,7 +22,7 @@ coloredlogs==15.0.1
     # via wipac-dev-tools
 contourpy==1.0.7
     # via matplotlib
-cryptography==39.0.1
+cryptography==39.0.2
     # via pyjwt
 cycler==0.11.0
     # via matplotlib
@@ -117,5 +117,5 @@ wipac-dev-tools[coloredlogs]==1.6.12
     #   oms-mqclient
     #   skymap-scanner (setup.py)
     #   wipac-rest-tools
-wipac-rest-tools==1.4.13
+wipac-rest-tools==1.4.14
     # via skymap-scanner (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ coloredlogs==15.0.1
     # via wipac-dev-tools
 contourpy==1.0.7
     # via matplotlib
-cryptography==39.0.1
+cryptography==39.0.2
     # via pyjwt
 cycler==0.11.0
     # via matplotlib
@@ -115,5 +115,5 @@ wipac-dev-tools[coloredlogs]==1.6.12
     #   oms-mqclient
     #   skymap-scanner (setup.py)
     #   wipac-rest-tools
-wipac-rest-tools==1.4.13
+wipac-rest-tools==1.4.14
     # via skymap-scanner (setup.py)


### PR DESCRIPTION
We want to skip long CI tests on `main` but we do want them to run when a release is made.

~We also don't want the setup-action to auto-push on `main`~