### PR TITLE
Simplification and improvement of GCD handling

### DIFF
--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -71,7 +71,7 @@ humanfriendly==10.0
     # via coloredlogs
 idna==3.4
     # via requests
-iminuit==2.20.0
+iminuit==2.21.0
     # via skymap-scanner (setup.py)
 kiwisolver==1.4.4
     # via matplotlib

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -75,7 +75,7 @@ iminuit==2.21.0
     # via skymap-scanner (setup.py)
 kiwisolver==1.4.4
     # via matplotlib
-matplotlib==3.7.0
+matplotlib==3.7.1
     # via
     #   healpy
     #   skymap-scanner (setup.py)

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -20,7 +20,7 @@ certifi==2022.12.7
     #   requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 coloredlogs==15.0.1
     # via wipac-dev-tools

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -34,7 +34,7 @@ ed25519==1.5
     # via nkeys
 ewms-pilot==0.4.1
     # via skymap-scanner (setup.py)
-fonttools==4.38.0
+fonttools==4.39.0
     # via matplotlib
 google-api-core[grpc]==2.11.0
     # via

--- a/requirements-client-starter.txt
+++ b/requirements-client-starter.txt
@@ -32,7 +32,7 @@ fonttools==4.39.0
     # via matplotlib
 healpy==1.16.2
     # via skymap-scanner (setup.py)
-htcondor==10.2.3
+htcondor==10.3.0
     # via skymap-scanner (setup.py)
 humanfriendly==10.0
     # via coloredlogs

--- a/requirements-client-starter.txt
+++ b/requirements-client-starter.txt
@@ -42,7 +42,7 @@ iminuit==2.21.0
     # via skymap-scanner (setup.py)
 kiwisolver==1.4.4
     # via matplotlib
-matplotlib==3.7.0
+matplotlib==3.7.1
     # via
     #   healpy
     #   skymap-scanner (setup.py)

--- a/requirements-client-starter.txt
+++ b/requirements-client-starter.txt
@@ -38,7 +38,7 @@ humanfriendly==10.0
     # via coloredlogs
 idna==3.4
     # via requests
-iminuit==2.20.0
+iminuit==2.21.0
     # via skymap-scanner (setup.py)
 kiwisolver==1.4.4
     # via matplotlib

--- a/requirements-client-starter.txt
+++ b/requirements-client-starter.txt
@@ -28,7 +28,7 @@ cycler==0.11.0
     # via matplotlib
 ewms-pilot==0.4.1
     # via skymap-scanner (setup.py)
-fonttools==4.38.0
+fonttools==4.39.0
     # via matplotlib
 healpy==1.16.2
     # via skymap-scanner (setup.py)

--- a/requirements-client-starter.txt
+++ b/requirements-client-starter.txt
@@ -16,7 +16,7 @@ certifi==2022.12.7
     # via requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 coloredlogs==15.0.1
     # via wipac-dev-tools

--- a/requirements-gcp.txt
+++ b/requirements-gcp.txt
@@ -30,7 +30,7 @@ cycler==0.11.0
     # via matplotlib
 ewms-pilot==0.4.1
     # via skymap-scanner (setup.py)
-fonttools==4.38.0
+fonttools==4.39.0
     # via matplotlib
 google-api-core[grpc]==2.11.0
     # via

--- a/requirements-gcp.txt
+++ b/requirements-gcp.txt
@@ -71,7 +71,7 @@ iminuit==2.21.0
     # via skymap-scanner (setup.py)
 kiwisolver==1.4.4
     # via matplotlib
-matplotlib==3.7.0
+matplotlib==3.7.1
     # via
     #   healpy
     #   skymap-scanner (setup.py)

--- a/requirements-gcp.txt
+++ b/requirements-gcp.txt
@@ -18,7 +18,7 @@ certifi==2022.12.7
     # via requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 coloredlogs==15.0.1
     # via wipac-dev-tools

--- a/requirements-gcp.txt
+++ b/requirements-gcp.txt
@@ -67,7 +67,7 @@ humanfriendly==10.0
     # via coloredlogs
 idna==3.4
     # via requests
-iminuit==2.20.0
+iminuit==2.21.0
     # via skymap-scanner (setup.py)
 kiwisolver==1.4.4
     # via matplotlib

--- a/requirements-nats.txt
+++ b/requirements-nats.txt
@@ -30,7 +30,7 @@ ed25519==1.5
     # via nkeys
 ewms-pilot==0.4.1
     # via skymap-scanner (setup.py)
-fonttools==4.38.0
+fonttools==4.39.0
     # via matplotlib
 healpy==1.16.2
     # via skymap-scanner (setup.py)

--- a/requirements-nats.txt
+++ b/requirements-nats.txt
@@ -42,7 +42,7 @@ iminuit==2.21.0
     # via skymap-scanner (setup.py)
 kiwisolver==1.4.4
     # via matplotlib
-matplotlib==3.7.0
+matplotlib==3.7.1
     # via
     #   healpy
     #   skymap-scanner (setup.py)

--- a/requirements-nats.txt
+++ b/requirements-nats.txt
@@ -38,7 +38,7 @@ humanfriendly==10.0
     # via coloredlogs
 idna==3.4
     # via requests
-iminuit==2.20.0
+iminuit==2.21.0
     # via skymap-scanner (setup.py)
 kiwisolver==1.4.4
     # via matplotlib

--- a/requirements-nats.txt
+++ b/requirements-nats.txt
@@ -16,7 +16,7 @@ certifi==2022.12.7
     # via requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 coloredlogs==15.0.1
     # via wipac-dev-tools

--- a/requirements-pulsar.txt
+++ b/requirements-pulsar.txt
@@ -30,7 +30,7 @@ cycler==0.11.0
     # via matplotlib
 ewms-pilot==0.4.1
     # via skymap-scanner (setup.py)
-fonttools==4.38.0
+fonttools==4.39.0
     # via matplotlib
 healpy==1.16.2
     # via skymap-scanner (setup.py)

--- a/requirements-pulsar.txt
+++ b/requirements-pulsar.txt
@@ -42,7 +42,7 @@ iminuit==2.21.0
     # via skymap-scanner (setup.py)
 kiwisolver==1.4.4
     # via matplotlib
-matplotlib==3.7.0
+matplotlib==3.7.1
     # via
     #   healpy
     #   skymap-scanner (setup.py)

--- a/requirements-pulsar.txt
+++ b/requirements-pulsar.txt
@@ -38,7 +38,7 @@ humanfriendly==10.0
     # via coloredlogs
 idna==3.4
     # via requests
-iminuit==2.20.0
+iminuit==2.21.0
     # via skymap-scanner (setup.py)
 kiwisolver==1.4.4
     # via matplotlib

--- a/requirements-pulsar.txt
+++ b/requirements-pulsar.txt
@@ -18,7 +18,7 @@ certifi==2022.12.7
     #   requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 coloredlogs==15.0.1
     # via wipac-dev-tools

--- a/requirements-rabbitmq.txt
+++ b/requirements-rabbitmq.txt
@@ -40,7 +40,7 @@ iminuit==2.21.0
     # via skymap-scanner (setup.py)
 kiwisolver==1.4.4
     # via matplotlib
-matplotlib==3.7.0
+matplotlib==3.7.1
     # via
     #   healpy
     #   skymap-scanner (setup.py)

--- a/requirements-rabbitmq.txt
+++ b/requirements-rabbitmq.txt
@@ -28,7 +28,7 @@ cycler==0.11.0
     # via matplotlib
 ewms-pilot==0.4.1
     # via skymap-scanner (setup.py)
-fonttools==4.38.0
+fonttools==4.39.0
     # via matplotlib
 healpy==1.16.2
     # via skymap-scanner (setup.py)

--- a/requirements-rabbitmq.txt
+++ b/requirements-rabbitmq.txt
@@ -36,7 +36,7 @@ humanfriendly==10.0
     # via coloredlogs
 idna==3.4
     # via requests
-iminuit==2.20.0
+iminuit==2.21.0
     # via skymap-scanner (setup.py)
 kiwisolver==1.4.4
     # via matplotlib

--- a/requirements-rabbitmq.txt
+++ b/requirements-rabbitmq.txt
@@ -16,7 +16,7 @@ certifi==2022.12.7
     # via requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 coloredlogs==15.0.1
     # via wipac-dev-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ iminuit==2.21.0
     # via skymap-scanner (setup.py)
 kiwisolver==1.4.4
     # via matplotlib
-matplotlib==3.7.0
+matplotlib==3.7.1
     # via
     #   healpy
     #   skymap-scanner (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ coloredlogs==15.0.1
     # via wipac-dev-tools
 contourpy==1.0.7
     # via matplotlib
-cryptography==39.0.1
+cryptography==39.0.2
     # via pyjwt
 cycler==0.11.0
     # via matplotlib
@@ -115,5 +115,5 @@ wipac-dev-tools[coloredlogs]==1.6.12
     #   oms-mqclient
     #   skymap-scanner (setup.py)
     #   wipac-rest-tools
-wipac-rest-tools==1.4.13
+wipac-rest-tools==1.4.14
     # via skymap-scanner (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ cycler==0.11.0
     # via matplotlib
 ewms-pilot==0.4.1
     # via skymap-scanner (setup.py)
-fonttools==4.38.0
+fonttools==4.39.0
     # via matplotlib
 healpy==1.16.2
     # via skymap-scanner (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ humanfriendly==10.0
     # via coloredlogs
 idna==3.4
     # via requests
-iminuit==2.20.0
+iminuit==2.21.0
     # via skymap-scanner (setup.py)
 kiwisolver==1.4.4
     # via matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ certifi==2022.12.7
     # via requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 coloredlogs==15.0.1
     # via wipac-dev-tools

--- a/resources/utils/save_scan_result.py
+++ b/resources/utils/save_scan_result.py
@@ -33,12 +33,9 @@ def main():
     )
     args = parser.parse_args()
 
-    stagers = dataio.get_stagers()
-
     state_dict = load_cache_state(
         args.event,
         cfg.RecoAlgo[args.reco_algo.upper()],
-        filestager=stagers,
         cache_dir=args.cache,
     )
 

--- a/resources/utils/save_scan_result.py
+++ b/resources/utils/save_scan_result.py
@@ -8,7 +8,6 @@ import argparse
 import logging
 
 import skymap_scanner.config as cfg
-from icecube import dataio
 from skymap_scanner.utils.load_scan_state import load_cache_state
 from skymap_scanner.utils.scan_result import ScanResult
 

--- a/skymap_scanner/client/reco_icetray.py
+++ b/skymap_scanner/client/reco_icetray.py
@@ -87,35 +87,29 @@ def get_baseline_GCD_handle(baseline_GCD_file: str) -> Any:
     """Find an available GCD base path."""
     stagers = dataio.get_stagers()
 
-    LOGGER.debug(f"Look up baseline GCD at {baseline_GCD_file}")
+    LOGGER.debug(f"Baseline GCD at {baseline_GCD_file}")
 
-    # try to load the base file from the various possible input directories
-    GCD_diff_base_handle = None
+    # assuming baseline_GCD_file is a valid GCD path!
+    # NOTE: old code use to search for a basename in a list of GCD_BASE_DIRS
+    baseline_GCD_handle = None
     if baseline_GCD_file not in [None, "None"]:
-        for GCD_base_dir in cfg.GCD_BASE_DIRS:
-            try:
-                read_url = os.path.join(GCD_base_dir, baseline_GCD_file)
-                LOGGER.debug("reading baseline GCD from {0}".format(read_url))
-                GCD_diff_base_handle = stagers.GetReadablePath(read_url)
-                if not os.path.isfile(str(GCD_diff_base_handle)):
-                    raise RuntimeError("file does not exist (or is not a file)")
-            except:
-                LOGGER.debug(" -> failed")
-                GCD_diff_base_handle = None
-            if GCD_diff_base_handle is not None:
-                LOGGER.debug(" -> success")
-                break
+        try:
+            LOGGER.debug("reading baseline GCD from {0}".format(baseline_GCD_file))
+            baseline_GCD_handle = stagers.GetReadablePath(baseline_GCD_file)
+            if not os.path.isfile(str(baseline_GCD_handle)):
+                raise RuntimeError("file does not exist (or is not a file)")
+        except:
+            LOGGER.debug(" -> failed")
+            baseline_GCD_handle = None
+        if baseline_GCD_handle is not None:
+            LOGGER.debug(" -> success")
 
-        if GCD_diff_base_handle is None:
-            raise RuntimeError(
-                "Could not read the input GCD file '{0}' from any pre-configured location".format(
-                    baseline_GCD_file
-                )
-            )
+    if baseline_GCD_handle is None:
+        raise RuntimeError(f"Could not read the input GCD file '{baseline_GCD_file}'")
     else:
-        LOGGER.info("baseline_GCD_file is None! Is this expected?")
+        LOGGER.info("baseline_GCD_file is None. Likely frame packet is not a GCD diff.")
 
-    return GCD_diff_base_handle
+    return baseline_GCD_handle
 
 
 def reco_pixel(

--- a/skymap_scanner/client/reco_icetray.py
+++ b/skymap_scanner/client/reco_icetray.py
@@ -125,22 +125,13 @@ def reco_pixel(
     tray.AddModule(notifyStart, "notifyStart")
 
     # get GCD
-    @icetray.traysegment
-    def UncompressGCD(tray, name, base_GCD_path, base_GCD_filename):
-        tray.Add(
-            uncompress,
-            name + "_GCD_patch",
-            keep_compressed=False,
-            base_path=base_GCD_path,
-            base_filename=base_GCD_filename,
-        )
-
     if check_baseline_GCD(baseline_GCD_file):
         tray.Add(
-            UncompressGCD,
-            "GCD_uncompress",
-            base_GCD_path="", 
-            base_GCD_filename=baseline_GCD_file,
+            uncompress,
+            "GCD_uncompress_GCD_patch",
+            keep_compressed=False,
+            base_path="",
+            base_filename=baseline_GCD_file
         )
 
     # perform fit

--- a/skymap_scanner/client/reco_icetray.py
+++ b/skymap_scanner/client/reco_icetray.py
@@ -185,11 +185,9 @@ def reco_pixel(
                 f"Pickle-dumping reco {pixelreco.pixel_to_tuple(frame)}: "
                 f"{frame_for_logging(frame)} to {out_pkl}."
             )
-            # apparently baseline GCD is sufficient here, maybe filestager can be None
             geometry = get_baseline_gcd_frames(
                 baseline_GCD_file,
-                GCDQp_packet,
-                filestager=dataio.get_stagers(),
+                GCDQp_packet
             )[0]
             pixreco = pixelreco.PixelReco.from_i3frame(frame, geometry, reco_algo)
             LOGGER.info(f"PixelReco: {pixreco}")

--- a/skymap_scanner/client/reco_icetray.py
+++ b/skymap_scanner/client/reco_icetray.py
@@ -83,9 +83,11 @@ def save_to_disk_cache(frame: icetray.I3Frame, save_dir: Path) -> Path:
     return pixel_fname
 
 
-def get_GCD_diff_base_handle(baseline_GCD_file: str) -> Any:
+def get_baseline_GCD_handle(baseline_GCD_file: str) -> Any:
     """Find an available GCD base path."""
     stagers = dataio.get_stagers()
+
+    LOGGER.debug(f"Look up baseline GCD at {baseline_GCD_file}")
 
     # try to load the base file from the various possible input directories
     GCD_diff_base_handle = None
@@ -110,6 +112,8 @@ def get_GCD_diff_base_handle(baseline_GCD_file: str) -> Any:
                     baseline_GCD_file
                 )
             )
+    else:
+        LOGGER.info("baseline_GCD_file is None! Is this expected?")
 
     return GCD_diff_base_handle
 
@@ -155,12 +159,12 @@ def reco_pixel(
             base_filename=base_GCD_filename,
         )
 
-    if GCD_diff_base_handle := get_GCD_diff_base_handle(baseline_GCD_file):
+    if baseline_GCD_handle := get_baseline_GCD_handle(baseline_GCD_file):
         tray.Add(
             UncompressGCD,
             "GCD_uncompress",
             base_GCD_path="",
-            base_GCD_filename=str(GCD_diff_base_handle),
+            base_GCD_filename=str(baseline_GCD_handle),
         )
 
     # perform fit

--- a/skymap_scanner/config.py
+++ b/skymap_scanner/config.py
@@ -49,6 +49,7 @@ MSG_KEY_PFRAME: Final = "pframe"
 
 BASELINE_GCD_FILENAME = "base_GCD_for_diff.i3"
 SOURCE_BASELINE_GCD_METADATA = "original_base_GCD_for_diff_filename.txt"
+GCDQp_FILENAME = "GCDQp.i3"
 
 class RecoAlgo(enum.Enum):
     """The supported reconstruction algorithms."""

--- a/skymap_scanner/config.py
+++ b/skymap_scanner/config.py
@@ -47,6 +47,7 @@ STATEDICT_NSIDES: Final = "nsides"
 MSG_KEY_RECO_ALGO: Final = "reco_algo"
 MSG_KEY_PFRAME: Final = "pframe"
 
+BASELINE_GCD_FILENAME = "base_GCD_for_diff.i3"
 
 class RecoAlgo(enum.Enum):
     """The supported reconstruction algorithms."""

--- a/skymap_scanner/config.py
+++ b/skymap_scanner/config.py
@@ -14,17 +14,6 @@ from wipac_dev_tools import from_environment_as_dataclass
 # True constants
 #
 
-GCD_BASE_DIRS: Final = [
-    os.path.join(
-        os.environ["HOME"], "PoleBaseGCDs"
-    ),  # why can't we reach anything from the followup nodes???
-    "file:///data/user/followup/baseline_gcds",
-    "http://icecube:skua@convey.icecube.wisc.edu/data/user/followup/baseline_gcds",
-    "file:///data/exp/IceCube/2016/internal-system/PoleBaseGCDs",
-    "http://icecube:skua@convey.icecube.wisc.edu/data/exp/IceCube/2016/internal-system/PoleBaseGCDs",
-    "file:///cvmfs/icecube.opensciencegrid.org/users/steinrob/GCD/PoleBaseGCDs/",
-]
-
 DEFAULT_GCD_DIR: Path = Path("/opt/i3-data/baseline_gcds")
 
 MIN_NSIDE_DEFAULT: Final = 8
@@ -50,6 +39,7 @@ MSG_KEY_PFRAME: Final = "pframe"
 BASELINE_GCD_FILENAME = "base_GCD_for_diff.i3"
 SOURCE_BASELINE_GCD_METADATA = "original_base_GCD_for_diff_filename.txt"
 GCDQp_FILENAME = "GCDQp.i3"
+
 
 class RecoAlgo(enum.Enum):
     """The supported reconstruction algorithms."""

--- a/skymap_scanner/config.py
+++ b/skymap_scanner/config.py
@@ -48,6 +48,7 @@ MSG_KEY_RECO_ALGO: Final = "reco_algo"
 MSG_KEY_PFRAME: Final = "pframe"
 
 BASELINE_GCD_FILENAME = "base_GCD_for_diff.i3"
+SOURCE_BASELINE_GCD_METADATA = "original_base_GCD_for_diff_filename.txt"
 
 class RecoAlgo(enum.Enum):
     """The supported reconstruction algorithms."""

--- a/skymap_scanner/recos/dummy.py
+++ b/skymap_scanner/recos/dummy.py
@@ -7,7 +7,6 @@ import random
 from I3Tray import I3Units  # type: ignore[import]
 from icecube import (  # type: ignore[import]  # noqa: F401
     dataclasses,
-    dataio,
     frame_object_diff,
     gulliver,
     gulliver_modules,

--- a/skymap_scanner/recos/millipede_original.py
+++ b/skymap_scanner/recos/millipede_original.py
@@ -12,7 +12,6 @@ from I3Tray import I3Units  # type: ignore[import]
 from icecube import (  # type: ignore[import]  # noqa: F401
     VHESelfVeto,
     dataclasses,
-    dataio,
     frame_object_diff,
     gulliver,
     gulliver_modules,

--- a/skymap_scanner/recos/millipede_wilks.py
+++ b/skymap_scanner/recos/millipede_wilks.py
@@ -12,7 +12,6 @@ from I3Tray import I3Units  # type: ignore[import]
 from icecube import (  # type: ignore[import]  # noqa: F401
     VHESelfVeto,
     dataclasses,
-    dataio,
     frame_object_diff,
     gulliver,
     gulliver_modules,

--- a/skymap_scanner/server/choose_new_pixels_to_scan.py
+++ b/skymap_scanner/server/choose_new_pixels_to_scan.py
@@ -309,7 +309,7 @@ if __name__ == "__main__":
     (options,args) = parser.parse_args()
 
     if len(args) != 1:
-        raise RuntimeError("You need to specify exatcly one event ID")
+        raise RuntimeError("You need to specify exactly one event ID")
     eventID = args[0]
 
     state_dict = load_cache_state(

--- a/skymap_scanner/server/start_scan.py
+++ b/skymap_scanner/server/start_scan.py
@@ -477,7 +477,7 @@ class PixelsToReco:
 
         # Validate & read GCDQp_packet
         p_frame = GCDQp_packet[-1]
-        g_frame = get_baseline_gcd_frames(baseline_GCD, GCDQp_packet, None)[0]
+        g_frame = get_baseline_gcd_frames(baseline_GCD, GCDQp_packet)[0]
 
         if p_frame.Stop != icetray.I3Frame.Stream('p'):
             raise RuntimeError("Last frame of the GCDQp packet is not type 'p'.")

--- a/skymap_scanner/server/start_scan.py
+++ b/skymap_scanner/server/start_scan.py
@@ -1124,7 +1124,6 @@ def main() -> None:
     event_metadata, state_dict = extract_json_message.extract_json_message(
         event_contents,
         reco_algo=args.reco_algo,
-        filestager=dataio.get_stagers(),
         is_real_event=args.real_event,
         cache_dir=str(args.cache_dir),
         GCD_dir=str(args.gcd_dir),

--- a/skymap_scanner/server/start_scan.py
+++ b/skymap_scanner/server/start_scan.py
@@ -114,7 +114,7 @@ class ProgressReporter:
         self.reporter_start_time = 0.0
 
         self._call_order = {
-            "current_previous": {  # current_fucntion: previous_fucntion(s)
+            'current_previous': {  # current_fucntion: previous_fucntion(s)
                 self.precomputing_report: [None],
                 self.start_computing: [
                     self.precomputing_report,
@@ -124,17 +124,17 @@ class ProgressReporter:
                 self.final_computing_report: [self.record_pixreco],
                 self.after_computing_report: [self.final_computing_report],
             },
-            "last_called": None,
+            'last_called': None,
         }
 
     def _check_call_order(self, current: Callable) -> None:  # type: ignore[type-arg]
         """Make sure we're calling everything in order."""
         if (
-            self._call_order["last_called"]  # type: ignore[operator]
-            not in self._call_order["current_previous"][current]  # type: ignore[index]
+            self._call_order['last_called']  # type: ignore[operator]
+            not in self._call_order['current_previous'][current]  # type: ignore[index]
         ):
             RuntimeError(f"Out of order execution: {self._call_order['last_called']=}")
-        self._call_order["last_called"] = current  # type: ignore[assignment]
+        self._call_order['last_called'] = current  # type: ignore[assignment]
 
     async def precomputing_report(self) -> None:
         """Make a report before ANYTHING is computed."""
@@ -229,24 +229,24 @@ class ProgressReporter:
         time_before_reporter = self.reporter_start_time - self.global_start_time
         proc_stats = {
             "start": {
-                "entire scan": str(
+                'entire scan': str(
                     dt.datetime.fromtimestamp(int(self.global_start_time))
                 ),
                 # TODO: add a start time for each nside (async)
-                "this iteration": str(
+                'this iteration': str(
                     dt.datetime.fromtimestamp(int(self.reporter_start_time))
                 ),
             },
             "runtime": {
-                "prior processing": str(
+                'prior processing': str(
                     dt.timedelta(seconds=int(time_before_reporter))
                 ),
                 # TODO: remove 'iterations' -- no replacement b/c async, that's OK
-                "this iteration": str(dt.timedelta(seconds=int(elapsed))),
-                "this iteration + prior processing": str(
+                'this iteration': str(dt.timedelta(seconds=int(elapsed))),
+                'this iteration + prior processing': str(
                     dt.timedelta(seconds=int(elapsed + time_before_reporter))
                 ),
-                "total": str(
+                'total': str(
                     dt.timedelta(seconds=int(time.time() - self.global_start_time))
                 ),
             },
@@ -255,22 +255,22 @@ class ProgressReporter:
             return proc_stats
 
         secs_per_pixreco = elapsed / self.pixreco_ct
-        proc_stats["rate"] = {
-            "per-pixel": str(
+        proc_stats['rate'] = {
+            'per-pixel': str(
                 dt.timedelta(seconds=int(secs_per_pixreco * self.n_posvar))
             ),
-            "per-reco": str(dt.timedelta(seconds=int(secs_per_pixreco))),
+            'per-reco': str(dt.timedelta(seconds=int(secs_per_pixreco))),
         }
 
         if self.is_event_scan_done:
             # SCAN IS DONE
-            proc_stats["end"] = str(dt.datetime.fromtimestamp(int(time.time())))
-            proc_stats["finished"] = True
+            proc_stats['end'] = str(dt.datetime.fromtimestamp(int(time.time())))
+            proc_stats['finished'] = True
         else:
             # MAKE PREDICTIONS
             # NOTE: this is a simple average, may want to visit more sophisticated methods
             secs_predicted = elapsed / (self.pixreco_ct / self.n_pixreco)
-            proc_stats["predictions"] = {
+            proc_stats['predictions'] = {
                 # TODO:
                 # 'remaining': {
                 #     # counts are downplayed using 'amount remaining' so we never report percent done
@@ -278,17 +278,17 @@ class ProgressReporter:
                 #     'pixels': ###/###,
                 #     'recos': ####/####,
                 # },
-                "time left": {
+                'time left': {
                     # TODO: replace w/ 'entire scan'
-                    "this iteration": str(
+                    'this iteration': str(
                         dt.timedelta(seconds=int(secs_predicted - elapsed))
                     )
                 },
-                "total runtime at finish": {
+                'total runtime at finish': {
                     # TODO: replace w/ 'total reconstruction'
-                    "this iteration": str(dt.timedelta(seconds=int(secs_predicted))),
+                    'this iteration': str(dt.timedelta(seconds=int(secs_predicted))),
                     # TODO: replace w/ 'entire scan'
-                    "this iteration + prior processing": str(
+                    'this iteration + prior processing': str(
                         dt.timedelta(seconds=int(secs_predicted + time_before_reporter))
                     ),
                 },
@@ -307,17 +307,17 @@ class ProgressReporter:
         this_iteration = {}  # type: ignore[var-annotated]
         if self._n_pixreco is not None:
             this_iteration = {
-                "percent": (self.pixreco_ct / self.n_pixreco) * 100,
-                "pixels": f"{self.pixreco_ct/self.n_posvar}/{self.n_pixreco/self.n_posvar}",
-                "recos": f"{self.pixreco_ct}/{self.n_pixreco}",
+                'percent': (self.pixreco_ct / self.n_pixreco) * 100,
+                'pixels': f"{self.pixreco_ct/self.n_posvar}/{self.n_pixreco/self.n_posvar}",
+                'recos': f"{self.pixreco_ct}/{self.n_pixreco}",
             }
 
         return {
-            "by_nside": saved,
-            "total": sum(s for s in saved.values()),  # total completed pixels
+            'by_nside': saved,
+            'total': sum(s for s in saved.values()),  # total completed pixels
             # TODO: for #84: uncomment b/c this will now be scan-wide total & remove 'this iteration' dict
             # 'total_recos': self.pixreco_ct,
-            "this_iteration": this_iteration,  # TODO: remove for #84
+            'this_iteration': this_iteration,  # TODO: remove for #84
         }
 
     async def final_computing_report(self) -> None:
@@ -354,36 +354,36 @@ class ProgressReporter:
     async def _send_progress(
         self,
         summary_msg: str,
-        epilogue_msg: str = "",
+        epilogue_msg: str = '',
         total_n_pixreco: int = None,  # TODO: remove for https://github.com/icecube/skymap_scanner/issues/84
     ) -> None:
         """Send progress to SkyDriver (if the connection is established)."""
         progress = {
-            "summary": summary_msg,
-            "epilogue": epilogue_msg,
-            "tallies": self._get_tallies(),
-            "processing_stats": self._get_processing_progress(),
+            'summary': summary_msg,
+            'epilogue': epilogue_msg,
+            'tallies': self._get_tallies(),
+            'processing_stats': self._get_processing_progress(),
         }
         scan_metadata = {
-            "scan_id": self.scan_id,
-            "min_nside": self.min_nside,  # TODO: replace with nsides (https://github.com/icecube/skymap_scanner/issues/79)
-            "max_nside": self.max_nside,  # TODO: remove (https://github.com/icecube/skymap_scanner/issues/79)
-            "position_variations": self.n_posvar,
+            'scan_id': self.scan_id,
+            'min_nside': self.min_nside,  # TODO: replace with nsides (https://github.com/icecube/skymap_scanner/issues/79)
+            'max_nside': self.max_nside,  # TODO: remove (https://github.com/icecube/skymap_scanner/issues/79)
+            'position_variations': self.n_posvar,
         }
 
         if total_n_pixreco:
             # TODO: remove for https://github.com/icecube/skymap_scanner/issues/84
             # see _get_tallies()
-            progress["tallies"]["total_recos"] = total_n_pixreco
+            progress['tallies']['total_recos'] = total_n_pixreco
 
         LOGGER.info(pyobj_to_string_repr(progress))
         if not self.skydriver_rc:
             return
 
         body = {
-            "progress": progress,
-            "event_metadata": dc.asdict(self.event_metadata),
-            "scan_metadata": scan_metadata,
+            'progress': progress,
+            'event_metadata': dc.asdict(self.event_metadata),
+            'scan_metadata': scan_metadata,
         }
         await self.skydriver_rc.request("PATCH", f"/scan/manifest/{self.scan_id}", body)
 
@@ -396,7 +396,7 @@ class ProgressReporter:
         if not self.skydriver_rc:
             return result
 
-        body = {"json_dict": serialized, "is_final": self.is_event_scan_done}
+        body = {'json_dict': serialized, 'is_final': self.is_event_scan_done}
         await self.skydriver_rc.request("PUT", f"/scan/result/{self.scan_id}", body)
 
         return result
@@ -1057,7 +1057,7 @@ def main() -> None:
             # "each ':'-paired with their pixel extension value. "
             # "Example: --nsides 8:12 64:12 512:24"
         ),
-        nargs="*",
+        nargs='*',
         type=_nside_and_pixelextension,
     )
     # --real-event XOR --simulated-event
@@ -1065,12 +1065,12 @@ def main() -> None:
     group.add_argument(
         "--real-event",
         action="store_true",
-        help="include this flag if the event is real",
+        help='include this flag if the event is real',
     )
     group.add_argument(
         "--simulated-event",
         action="store_true",
-        help="include this flag if the event was simulated",
+        help='include this flag if the event was simulated',
     )
 
     args = parser.parse_args()
@@ -1126,7 +1126,7 @@ def main() -> None:
         reco_algo=args.reco_algo,
         is_real_event=args.real_event,
         cache_dir=str(args.cache_dir),
-        GCD_dir=str(args.gcd_dir),
+        GCD_dir=str(args.gcd_dir)
     )
 
     # write startup files for client-spawning

--- a/skymap_scanner/server/start_scan.py
+++ b/skymap_scanner/server/start_scan.py
@@ -21,7 +21,6 @@ from I3Tray import I3Units  # type: ignore[import]
 from icecube import (  # type: ignore[import]
     astro,
     dataclasses,
-    dataio,
     full_event_followup,
     icetray,
 )

--- a/skymap_scanner/utils/extract_json_message.py
+++ b/skymap_scanner/utils/extract_json_message.py
@@ -125,7 +125,7 @@ def __extract_frame_packet(
 
     # extract event ID
     if "I3EventHeader" not in physics_frame:
-        raise RuntimeError("No I3EventHeader in Physics frame")
+        raise RuntimeError("No I3EventHeader in Physics frame.")
     header = physics_frame["I3EventHeader"]
     event_metadata = EventMetadata(
         header.run_id,
@@ -137,11 +137,11 @@ def __extract_frame_packet(
     LOGGER.debug("event ID is {0}".format(event_metadata))
 
     # create the cache directory if necessary
-    this_event_cache_dir = os.path.join(cache_dir, str(event_metadata))
-    if os.path.exists(this_event_cache_dir) and not os.path.isdir(this_event_cache_dir):
-        raise RuntimeError("this event would be cached in directory \"{0}\", but it exists and is not a directory".format(this_event_cache_dir))
-    if not os.path.exists(this_event_cache_dir):
-        os.mkdir(this_event_cache_dir)
+    event_cache_dir = os.path.join(cache_dir, str(event_metadata))
+    if os.path.exists(event_cache_dir) and not os.path.isdir(event_cache_dir):
+        raise RuntimeError("This event would be cached in directory \"{0}\", but it exists and is not a directory.".format(event_cache_dir))
+    if not os.path.exists(event_cache_dir):
+        os.mkdir(event_cache_dir)
 
     # see if we have the required baseline GCD to which to apply the GCD diff
     
@@ -186,8 +186,8 @@ def __extract_frame_packet(
             LOGGER.debug(" -> success")
         else:
             raise RuntimeError("Could not read the input GCD file \"{baseline_GCD}\"")
-            
-        new_GCD_base_filename = os.path.join(this_event_cache_dir, "base_GCD_for_diff.i3")
+        
+        new_GCD_base_filename = os.path.join(event_cache_dir, cfg.BASELINE_GCD_FILENAME)
 
         diff_referenced = load_GCD_frame_packet_from_file( str(baseline_GCD_handle) )
         if os.path.exists(new_GCD_base_filename):
@@ -204,7 +204,7 @@ def __extract_frame_packet(
             LOGGER.debug("wrote baseline GCD frames to {0}".format(new_GCD_base_filename))
 
         # save the GCD filename
-        original_GCD_diff_base_filename = os.path.join(this_event_cache_dir, "original_base_GCD_for_diff_filename.txt")
+        original_GCD_diff_base_filename = os.path.join(event_cache_dir, "original_base_GCD_for_diff_filename.txt")
         if os.path.isfile(original_GCD_diff_base_filename):
             f = open(original_GCD_diff_base_filename, 'r')
             filename = f.read()
@@ -255,7 +255,7 @@ def __extract_frame_packet(
     # move the last packet frame from Physics to the 'p' stream
     frame_packet[-1] = rewrite_frame_stop(frame_packet[-1], icetray.I3Frame.Stream('p'))
 
-    GCDQp_filename = os.path.join(this_event_cache_dir, "GCDQp.i3")
+    GCDQp_filename = os.path.join(event_cache_dir, "GCDQp.i3")
     if os.path.exists(GCDQp_filename):
         # GCD already exists - check to make sure it is consistent
         this_packet_hash = hash_frame_packet(frame_packet)
@@ -272,7 +272,7 @@ def __extract_frame_packet(
         LOGGER.debug("wrote GCDQp dependency frames to {0}".format(GCDQp_filename))
 
     return (
-        this_event_cache_dir,
+        event_cache_dir,
         event_metadata,
         {
             cfg.STATEDICT_GCDQP_PACKET: frame_packet,

--- a/skymap_scanner/utils/extract_json_message.py
+++ b/skymap_scanner/utils/extract_json_message.py
@@ -105,7 +105,7 @@ def __extract_frame_packet(
     reco_algo: str,
     is_real_event: bool,
     cache_dir="./cache/",
-    GCD_dir=cfg.DEFAULT_GCD_DIR : str,
+    GCD_dir : str = cfg.DEFAULT_GCD_DIR,
     pulsesName="SplitUncleanedInIcePulses",
 ) -> Tuple[str, EventMetadata, dict]:
     if not os.path.exists(cache_dir):
@@ -233,7 +233,7 @@ def __extract_frame_packet(
 
     if baseline_GCD is not None:
         # frame_packet has GCD diff, provide baseline
-        frame_packet = prepare_frames(frame_packet, str(baseline_GCD_handle), reco_algo, pulsesName=pulsesName)
+        frame_packet = prepare_frames(frame_packet, baseline_GCD_file, reco_algo, pulsesName=pulsesName)
     else:
         # frame_packet has either normal GCD or has been reassembled
         frame_packet = prepare_frames(frame_packet, None, reco_algo, pulsesName=pulsesName)
@@ -242,6 +242,7 @@ def __extract_frame_packet(
     frame_packet[-1] = rewrite_frame_stop(frame_packet[-1], icetray.I3Frame.Stream('p'))
 
     cached_GCDQp = os.path.join(event_cache_dir, cfg.GCDQp_FILENAME)
+
     if os.path.exists(cached_GCDQp):
         # GCD already exists - check to make sure it is consistent
         GCDQp_framepacket_hash = hash_frame_packet(frame_packet)

--- a/skymap_scanner/utils/extract_json_message.py
+++ b/skymap_scanner/utils/extract_json_message.py
@@ -18,7 +18,7 @@ from .prepare_frames import prepare_frames
 from .utils import (
     get_event_mjd,
     hash_frame_packet,
-    load_GCD_frame_packet_from_file,
+    load_framepacket_file,
     rewrite_frame_stop,
     save_GCD_frame_packet_to_file,
 )
@@ -200,10 +200,10 @@ def __extract_frame_packet(
         
         cached_baseline_GCD = os.path.join(event_cache_dir, cfg.BASELINE_GCD_FILENAME)
 
-        baseline_GCD_framepacket = load_GCD_frame_packet_from_file( str(baseline_GCD_handle) )
+        baseline_GCD_framepacket = load_framepacket_file( str(baseline_GCD_handle) )
         if os.path.exists(cached_baseline_GCD):
             # this will never occur if the cache is isolated on a server-instance basis!
-            cached_baseline_GCD_framepacket = load_GCD_frame_packet_from_file(cached_baseline_GCD)
+            cached_baseline_GCD_framepacket = load_framepacket_file(cached_baseline_GCD)
             cached_baseline_GCD_hash = hash_frame_packet(cached_baseline_GCD_framepacket)
             baseline_GCD_hash = hash_frame_packet(baseline_GCD_framepacket)
             if cached_baseline_GCD_hash != baseline_GCD_hash:
@@ -251,7 +251,7 @@ def __extract_frame_packet(
         # if baseline_GCD_file is None:
         #    raise RuntimeError("Cannot continue - don't know which GCD to use for empty GCD event. Please
         # manually override GCD.")
-        baseline_GCD_framepacket = load_GCD_frame_packet_from_file(baseline_GCD_file)
+        baseline_GCD_framepacket = load_framepacket_file(baseline_GCD_file)
         frame_packet[0] = baseline_GCD_framepacket[0]
         frame_packet[1] = baseline_GCD_framepacket[1]
         frame_packet[2] = baseline_GCD_framepacket[2]
@@ -271,7 +271,7 @@ def __extract_frame_packet(
     if os.path.exists(cached_GCDQp):
         # GCD already exists - check to make sure it is consistent
         GCDQp_framepacket_hash = hash_frame_packet(frame_packet)
-        cached_QCDQp_framepacket = load_GCD_frame_packet_from_file(cached_GCDQp)
+        cached_QCDQp_framepacket = load_framepacket_file(cached_GCDQp)
         cached_GCDQp_framepacket_hash = hash_frame_packet(cached_QCDQp_framepacket)
         if GCDQp_framepacket_hash != cached_GCDQp_framepacket_hash:
             raise RuntimeError(f"Existing GCDQp packet in cache (SHA1 {cached_GCDQp_framepacket_hash}) and packet from input (SHA1 {GCDQp_framepacket_hash}) differ.")

--- a/skymap_scanner/utils/extract_json_message.py
+++ b/skymap_scanner/utils/extract_json_message.py
@@ -174,22 +174,22 @@ def __extract_frame_packet(
         # The following conditional structure could be a bit smarter.
         try:
             LOGGER.debug("reading GCD from {baseline_GCD_file}")
-            GCD_diff_base_handle = filestager.GetReadablePath(baseline_GCD_file)
-            if not os.path.isfile(str(GCD_diff_base_handle)):
+            baseline_GCD_handle = filestager.GetReadablePath(baseline_GCD_file)
+            if not os.path.isfile(str(baseline_GCD_handle)):
                 raise RuntimeError("File does not exist (or is not a file)")
         except:
             # why this is not an if-then? could GetReadablePath throw an exception?
             LOGGER.debug(" -> failed")
-            GCD_diff_base_handle = None
+            baseline_GCD_handle = None
             
-        if GCD_diff_base_handle is not None:
+        if baseline_GCD_handle is not None:
             LOGGER.debug(" -> success")
         else:
             raise RuntimeError("Could not read the input GCD file \"{baseline_GCD}\"")
             
         new_GCD_base_filename = os.path.join(this_event_cache_dir, "base_GCD_for_diff.i3")
 
-        diff_referenced = load_GCD_frame_packet_from_file( str(GCD_diff_base_handle) )
+        diff_referenced = load_GCD_frame_packet_from_file( str(baseline_GCD_handle) )
         if os.path.exists(new_GCD_base_filename):
             diff_in_cache = load_GCD_frame_packet_from_file(new_GCD_base_filename)
             diff_in_cache_hash = hash_frame_packet(diff_in_cache)
@@ -248,7 +248,7 @@ def __extract_frame_packet(
         del ehe_override_gcd
 
     if baseline_GCD is not None:
-        frame_packet = prepare_frames(frame_packet, str(GCD_diff_base_handle), reco_algo, pulsesName=pulsesName)
+        frame_packet = prepare_frames(frame_packet, str(baseline_GCD_handle), reco_algo, pulsesName=pulsesName)
     else:
         frame_packet = prepare_frames(frame_packet, None, reco_algo, pulsesName=pulsesName)
 

--- a/skymap_scanner/utils/extract_json_message.py
+++ b/skymap_scanner/utils/extract_json_message.py
@@ -167,7 +167,7 @@ def __extract_frame_packet(
         # input event had GCD diff frames!
         if GCD_dir is not None: # always true since we pass this as an argument!
             baseline_GCD_file = os.path.join(GCD_dir, baseline_GCD)
-            LOGGER.debug("Trying GCD file: {baseline_GCD_file}")
+            LOGGER.debug(f"Trying GCD file: {baseline_GCD_file}")
             if not os.path.isfile(baseline_GCD_file):
                 raise RuntimeError("Baseline GCD file not available!")
             # if the baseline GCD is found: GCD_dir == baseline_GCD == baseline_GCD_file
@@ -184,7 +184,7 @@ def __extract_frame_packet(
         # NOTE: we used to loop over a set of possible GCD_BASE_DIRS but it is no longer the case.
         # The following conditional structure could be a bit smarter.
         try:
-            LOGGER.debug("reading GCD from {baseline_GCD_file}")
+            LOGGER.debug(f"Reading GCD from {baseline_GCD_file}.")
             baseline_GCD_handle = filestager.GetReadablePath(baseline_GCD_file)
             if not os.path.isfile(str(baseline_GCD_handle)):
                 raise RuntimeError("File does not exist (or is not a file)")
@@ -286,6 +286,6 @@ def __extract_frame_packet(
         event_metadata,
         {
             cfg.STATEDICT_GCDQP_PACKET: frame_packet,
-            cfg.STATEDICT_BASELINE_GCD_FILE: baseline_GCD
+            cfg.STATEDICT_BASELINE_GCD_FILE: baseline_GCD_file
         },
     )

--- a/skymap_scanner/utils/extract_json_message.py
+++ b/skymap_scanner/utils/extract_json_message.py
@@ -8,7 +8,7 @@ import os
 from typing import Tuple
 
 import numpy as np
-from icecube import dataio, full_event_followup, icetray  # type: ignore[import]
+from icecube import full_event_followup, icetray  # type: ignore[import]
 
 from .. import config as cfg
 from . import LOGGER

--- a/skymap_scanner/utils/extract_json_message.py
+++ b/skymap_scanner/utils/extract_json_message.py
@@ -18,7 +18,7 @@ from .prepare_frames import prepare_frames
 from .utils import (
     get_event_mjd,
     hash_frame_packet,
-    load_framepacket_file,
+    load_framepacket_from_file,
     rewrite_frame_stop,
     save_GCD_frame_packet_to_file,
 )
@@ -200,10 +200,10 @@ def __extract_frame_packet(
         
         cached_baseline_GCD = os.path.join(event_cache_dir, cfg.BASELINE_GCD_FILENAME)
 
-        baseline_GCD_framepacket = load_framepacket_file( str(baseline_GCD_handle) )
+        baseline_GCD_framepacket = load_framepacket_from_file( str(baseline_GCD_handle) )
         if os.path.exists(cached_baseline_GCD):
             # this will never occur if the cache is isolated on a server-instance basis!
-            cached_baseline_GCD_framepacket = load_framepacket_file(cached_baseline_GCD)
+            cached_baseline_GCD_framepacket = load_framepacket_from_file(cached_baseline_GCD)
             cached_baseline_GCD_hash = hash_frame_packet(cached_baseline_GCD_framepacket)
             baseline_GCD_hash = hash_frame_packet(baseline_GCD_framepacket)
             if cached_baseline_GCD_hash != baseline_GCD_hash:
@@ -251,7 +251,7 @@ def __extract_frame_packet(
         # if baseline_GCD_file is None:
         #    raise RuntimeError("Cannot continue - don't know which GCD to use for empty GCD event. Please
         # manually override GCD.")
-        baseline_GCD_framepacket = load_framepacket_file(baseline_GCD_file)
+        baseline_GCD_framepacket = load_framepacket_from_file(baseline_GCD_file)
         frame_packet[0] = baseline_GCD_framepacket[0]
         frame_packet[1] = baseline_GCD_framepacket[1]
         frame_packet[2] = baseline_GCD_framepacket[2]
@@ -271,7 +271,7 @@ def __extract_frame_packet(
     if os.path.exists(cached_GCDQp):
         # GCD already exists - check to make sure it is consistent
         GCDQp_framepacket_hash = hash_frame_packet(frame_packet)
-        cached_QCDQp_framepacket = load_framepacket_file(cached_GCDQp)
+        cached_QCDQp_framepacket = load_framepacket_from_file(cached_GCDQp)
         cached_GCDQp_framepacket_hash = hash_frame_packet(cached_QCDQp_framepacket)
         if GCDQp_framepacket_hash != cached_GCDQp_framepacket_hash:
             raise RuntimeError(f"Existing GCDQp packet in cache (SHA1 {cached_GCDQp_framepacket_hash}) and packet from input (SHA1 {GCDQp_framepacket_hash}) differ.")

--- a/skymap_scanner/utils/extract_json_message.py
+++ b/skymap_scanner/utils/extract_json_message.py
@@ -219,10 +219,6 @@ def __extract_frame_packet(
 
         LOGGER.debug((available_GCDs, run))
         LOGGER.debug(f"By process of elimination using run numbers, using {baseline_GCD_file}")
-        # NOTE: commented because it should never occur
-        # if baseline_GCD_file is None:
-        #    raise RuntimeError("Cannot continue - don't know which GCD to use for empty GCD event. Please
-        # manually override GCD.")
         baseline_GCD_framepacket = load_framepacket_from_file(baseline_GCD_file)
         for i in (0,1,2):
             frame_packet[i] = baseline_GCD_framepacket[i]

--- a/skymap_scanner/utils/extract_json_message.py
+++ b/skymap_scanner/utils/extract_json_message.py
@@ -154,6 +154,7 @@ def __extract_frame_packet(
     # - cache baseline GCD file and medatadata (check consistency if already cached)
     # if packet does not have GCD (GFU event or legacy EHE)
     # - look up baseline GCD in GCD_dir based on run number
+    # - assemble GCDQp from baseline GCD
 
     LOGGER.debug(f"Extracted GCD_diff_base_filename = {baseline_GCD}.")
     LOGGER.debug(f"GCD dir is set to = {GCD_dir}.")

--- a/skymap_scanner/utils/extract_json_message.py
+++ b/skymap_scanner/utils/extract_json_message.py
@@ -52,7 +52,6 @@ def extract_GCD_diff_base_filename(frame_packet):
 def extract_json_message(
     json_data,
     reco_algo: str,
-    filestager,
     is_real_event: bool,
     cache_dir="./cache/",
     GCD_dir=None,
@@ -67,7 +66,6 @@ def extract_json_message(
 
     _, event_metadata, state_dict = __extract_frame_packet(
         frame_packet,
-        filestager=filestager,
         reco_algo=reco_algo,
         is_real_event=is_real_event,
         cache_dir=cache_dir,
@@ -101,7 +99,6 @@ def __extract_event_type(physics_frame):
 
 def __extract_frame_packet(
     frame_packet,
-    filestager,
     reco_algo: str,
     is_real_event: bool,
     cache_dir="./cache/",

--- a/skymap_scanner/utils/load_scan_state.py
+++ b/skymap_scanner/utils/load_scan_state.py
@@ -42,33 +42,19 @@ def get_baseline_gcd_frames(baseline_GCD_file, GCDQp_packet, filestager) -> List
 
     if baseline_GCD_file is not None:
           
-        LOGGER.debug("trying to read GCD from {0}".format(baseline_GCD_file))
+        LOGGER.debug(f"Trying to read GCD from {baseline_GCD_file}.")
         try:
             baseline_GCD_frames = load_GCD_frame_packet_from_file(baseline_GCD_file, filestager=filestager)
         except:
-            baseline_GCD_frames = None
             LOGGER.debug(" -> failed")
+            raise RuntimeError("Unable to read baseline GCD. In the current design, this is unexpected. Possibly a bug or data corruption!")
         if baseline_GCD_frames is not None:
             LOGGER.debug(" -> success")
+        # NOTE: Legacy code used to scan a list of GCD_BASE_DIRS.
+        #       It is now assumed that assume that the passed `baseline_GCD_file` is a valid path to a baseline GCD file.
 
-        if baseline_GCD_frames is None:
-            for GCD_base_dir in cfg.GCD_BASE_DIRS:
-                read_url = os.path.join(GCD_base_dir, baseline_GCD_file)
-                LOGGER.debug("trying to read GCD from {0}".format(read_url))
-                try:
-                    baseline_GCD_frames = load_GCD_frame_packet_from_file(read_url, filestager=filestager)                
-                except:
-                    LOGGER.debug(" -> failed")
-                    baseline_GCD_frames=None
-
-                if baseline_GCD_frames is not None:
-                    LOGGER.debug(" -> success")
-                    break
-
-            if baseline_GCD_frames is None:
-                raise RuntimeError("Could not load basline GCD file from any location")
     else:
-        # assume we have full non-diff GCD frames in the packet
+        # Assume we have full non-diff GCD frames in the packet.
         baseline_GCD_frames = [GCDQp_packet[0]]
         if "I3Geometry" not in baseline_GCD_frames[0]:
             raise RuntimeError("No baseline GCD file available but main packet G frame does not contain I3Geometry")

--- a/skymap_scanner/utils/load_scan_state.py
+++ b/skymap_scanner/utils/load_scan_state.py
@@ -126,7 +126,7 @@ def load_scan_state(
 
 def load_GCDQp_state(event_metadata: EventMetadata, filestager=None, cache_dir="./cache/") -> dict:
     this_event_cache_dir = os.path.join(cache_dir, str(event_metadata))
-    GCDQp_filename = os.path.join(this_event_cache_dir, "GCDQp.i3")
+    GCDQp_filename = os.path.join(this_event_cache_dir, cfg.GCDQp_FILENAME)
     potential_GCD_diff_base_filename = os.path.join(this_event_cache_dir, cfg.BASELINE_GCD_FILENAME)
 
     potential_original_GCD_diff_base_filename = os.path.join(this_event_cache_dir, cfg.SOURCE_BASELINE_GCD_METADATA)

--- a/skymap_scanner/utils/load_scan_state.py
+++ b/skymap_scanner/utils/load_scan_state.py
@@ -19,7 +19,6 @@ from .utils import hash_frame_packet, load_framepacket_from_file
 def load_cache_state(
     event_metadata: EventMetadata,
     reco_algo: str,
-    filestager=None,
     cache_dir: str = "./cache/",
 ) -> dict:
     this_event_cache_dir = os.path.join(cache_dir, str(event_metadata))
@@ -28,11 +27,11 @@ def load_cache_state(
 
     # load GCDQp state first
     LOGGER.debug("Initialize state_dict with GCDQp")
-    state_dict = load_GCDQp_state(event_metadata, filestager=filestager, cache_dir=cache_dir)
+    state_dict = load_GCDQp_state(event_metadata, cache_dir=cache_dir)
 
     # update with scans
     LOGGER.debug("Update state_dict with scan state.")
-    state_dict = load_scan_state(event_metadata, state_dict, reco_algo, filestager=filestager, cache_dir=cache_dir)[1]
+    state_dict = load_scan_state(event_metadata, state_dict, reco_algo, cache_dir=cache_dir)[1]
 
     return state_dict
 
@@ -67,7 +66,6 @@ def load_scan_state(
     event_metadata: EventMetadata,
     state_dict: dict,
     reco_algo: str,
-    filestager=None,
     cache_dir: str = "./cache/"
 ) -> dict:
     
@@ -202,7 +200,6 @@ if __name__ == "__main__":
     packets = load_cache_state(
         eventID,
         args.reco_algo,  # TODO: add --reco-algo (see start_scan.py)
-        filestager=stagers,
         cache_dir=options.CACHEDIR
     )
 

--- a/skymap_scanner/utils/load_scan_state.py
+++ b/skymap_scanner/utils/load_scan_state.py
@@ -139,17 +139,17 @@ def load_GCDQp_state(event_metadata: EventMetadata, filestager=None, cache_dir="
             raise RuntimeError(f"Cache state seems to require a baseline GCD file (it contains a cached version), but the cache does not have \"{cfg.SOURCE_BASELINE_GCD_METADATA}\". This is a bug or corrupted data.")
         else:
             if filestager is None:
-                orig_packet = None
+                source_baseline_GCD = None
                 for GCD_base_dir in cfg.GCD_BASE_DIRS:
                     try:
                         read_path = os.path.join(GCD_base_dir, source_baseline_GCD_metadata)
-                        LOGGER.debug("load_GCDQp_state => reading GCD from {0}".format(read_path))
-                        orig_packet = load_framepacket_from_file(read_path)
+                        LOGGER.debug("load_GCDQp_state => reading source baseline GCD from {0}".format(read_path))
+                        source_baseline_GCD = load_framepacket_from_file(read_path)
                     except:
                         LOGGER.debug(" -> failed")
-                        orig_packet = None
-                    if orig_packet is None:
-                        raise RuntimeError("load_GCDQp_state => Could not read the input GCD file \"{0}\" from any pre-configured location".format(source_baseline_GCD_metadata))
+                        source_baseline_GCD = None
+                    if source_baseline_GCD is None:
+                        raise RuntimeError("load_GCDQp_state => Could not read the source GCD file \"{0}\" from any pre-configured location".format(source_baseline_GCD_metadata))
             else:
                 # try to load the base file from the various possible input directories
                 GCD_diff_base_handle = None
@@ -170,15 +170,15 @@ def load_GCDQp_state(event_metadata: EventMetadata, filestager=None, cache_dir="
                 if GCD_diff_base_handle is None:
                     raise RuntimeError("Could not read the input GCD file \"{0}\" from any pre-configured location".format(source_baseline_GCD_metadata))
 
-                orig_packet = load_framepacket_from_file( str(GCD_diff_base_handle) )
+                source_baseline_GCD = load_framepacket_from_file( str(GCD_diff_base_handle) )
             this_packet = load_framepacket_from_file(cached_baseline_GCD)
             
-            orig_packet_hash = hash_frame_packet(orig_packet)
+            orig_packet_hash = hash_frame_packet(source_baseline_GCD)
             this_packet_hash = hash_frame_packet(this_packet)
             if orig_packet_hash != this_packet_hash:
                 raise RuntimeError("cached GCD baseline file is different from the original file")
 
-            del orig_packet
+            del source_baseline_GCD
             del this_packet
             
             LOGGER.debug(" - has a frame diff packet at {0} (using original copy)".format(os.path.join(GCD_base_dir, source_baseline_GCD_metadata)))

--- a/skymap_scanner/utils/load_scan_state.py
+++ b/skymap_scanner/utils/load_scan_state.py
@@ -27,9 +27,11 @@ def load_cache_state(
         raise NotADirectoryError("event \"{0}\" not found in cache at \"{1}\".".format(str(event_metadata), this_event_cache_dir))
 
     # load GCDQp state first
+    LOGGER.debug("Initialize state_dict with GCDQp state.")
     state_dict = load_GCDQp_state(event_metadata, filestager=filestager, cache_dir=cache_dir)
 
     # update with scans
+    LOGGER.debug("Update state_dict with scan state.")
     state_dict = load_scan_state(event_metadata, state_dict, reco_algo, filestager=filestager, cache_dir=cache_dir)[1]
 
     return state_dict

--- a/skymap_scanner/utils/load_scan_state.py
+++ b/skymap_scanner/utils/load_scan_state.py
@@ -13,7 +13,7 @@ from .. import config as cfg
 from . import LOGGER
 from .event_tools import EventMetadata
 from .pixelreco import PixelReco
-from .utils import hash_frame_packet, load_GCD_frame_packet_from_file
+from .utils import hash_frame_packet, load_framepacket_file
 
 
 def load_cache_state(
@@ -44,7 +44,7 @@ def get_baseline_gcd_frames(baseline_GCD_file, GCDQp_packet, filestager) -> List
           
         LOGGER.debug(f"Trying to read GCD from {baseline_GCD_file}.")
         try:
-            baseline_GCD_frames = load_GCD_frame_packet_from_file(baseline_GCD_file, filestager=filestager)
+            baseline_GCD_frames = load_framepacket_file(baseline_GCD_file, filestager=filestager)
         except:
             LOGGER.debug(" -> failed")
             raise RuntimeError("Unable to read baseline GCD. In the current design, this is unexpected. Possibly a bug or data corruption!")
@@ -92,7 +92,7 @@ def load_scan_state(
         pixels = [(int(d[3:-3]), os.path.join(nside_dir, d)) for d in os.listdir(nside_dir) if os.path.isfile(os.path.join(nside_dir, d)) and d.startswith("pix") and d.endswith(".i3")]
 
         for pixel, pixel_file in pixels:
-            loaded_frames = load_GCD_frame_packet_from_file(pixel_file)
+            loaded_frames = load_framepacket_file(pixel_file)
             if len(loaded_frames) == 0:
                 continue  # skip empty files
             if len(loaded_frames) > 1:
@@ -126,13 +126,13 @@ def load_GCDQp_state(event_metadata: EventMetadata, filestager=None, cache_dir="
     if not os.path.isfile(GCDQp_filename):
         raise RuntimeError("event \"{0}\" not found in cache at \"{1}\".".format(str(event_metadata), GCDQp_filename))
 
-    frame_packet = load_GCD_frame_packet_from_file(GCDQp_filename)
+    frame_packet = load_framepacket_file(GCDQp_filename)
     LOGGER.debug("loaded frame packet from {0}".format(GCDQp_filename))
 
     if os.path.isfile(potential_GCD_diff_base_filename):
         if potential_original_GCD_diff_base_filename is None:
             # load and throw away to make sure it is readable
-            load_GCD_frame_packet_from_file(potential_GCD_diff_base_filename)
+            load_framepacket_file(potential_GCD_diff_base_filename)
             LOGGER.debug(" - has a frame diff packet at {0}".format(potential_GCD_diff_base_filename))
             GCD_diff_base_filename = potential_GCD_diff_base_filename
             
@@ -144,7 +144,7 @@ def load_GCDQp_state(event_metadata: EventMetadata, filestager=None, cache_dir="
                     try:
                         read_path = os.path.join(GCD_base_dir, potential_original_GCD_diff_base_filename)
                         LOGGER.debug("reading GCD from {0}".format(read_path))
-                        orig_packet = load_GCD_frame_packet_from_file(read_path)
+                        orig_packet = load_framepacket_file(read_path)
                     except:
                         LOGGER.debug(" -> failed")
                         orig_packet = None
@@ -170,8 +170,8 @@ def load_GCDQp_state(event_metadata: EventMetadata, filestager=None, cache_dir="
                 if GCD_diff_base_handle is None:
                     raise RuntimeError("Could not read the input GCD file \"{0}\" from any pre-configured location".format(potential_original_GCD_diff_base_filename))
 
-                orig_packet = load_GCD_frame_packet_from_file( str(GCD_diff_base_handle) )
-            this_packet = load_GCD_frame_packet_from_file(potential_GCD_diff_base_filename)
+                orig_packet = load_framepacket_file( str(GCD_diff_base_handle) )
+            this_packet = load_framepacket_file(potential_GCD_diff_base_filename)
             
             orig_packet_hash = hash_frame_packet(orig_packet)
             this_packet_hash = hash_frame_packet(this_packet)

--- a/skymap_scanner/utils/load_scan_state.py
+++ b/skymap_scanner/utils/load_scan_state.py
@@ -127,7 +127,7 @@ def load_scan_state(
 def load_GCDQp_state(event_metadata: EventMetadata, filestager=None, cache_dir="./cache/") -> dict:
     this_event_cache_dir = os.path.join(cache_dir, str(event_metadata))
     GCDQp_filename = os.path.join(this_event_cache_dir, "GCDQp.i3")
-    potential_GCD_diff_base_filename = os.path.join(this_event_cache_dir, "base_GCD_for_diff.i3")
+    potential_GCD_diff_base_filename = os.path.join(this_event_cache_dir, cfg.BASELINE_GCD_FILENAME)
 
     potential_original_GCD_diff_base_filename = os.path.join(this_event_cache_dir, "original_base_GCD_for_diff_filename.txt")
     if os.path.isfile(potential_original_GCD_diff_base_filename):

--- a/skymap_scanner/utils/load_scan_state.py
+++ b/skymap_scanner/utils/load_scan_state.py
@@ -7,7 +7,7 @@
 import os
 from typing import List
 
-from icecube import dataio, icetray
+from icecube import icetray
 
 from .. import config as cfg
 from . import LOGGER
@@ -192,9 +192,6 @@ if __name__ == "__main__":
     if len(args) != 1:
         raise RuntimeError("You need to specify exatcly one event ID")
     eventID = args[0]
-
-    # get the file stager instance
-    stagers = dataio.get_stagers()
 
     # do the work
     packets = load_cache_state(

--- a/skymap_scanner/utils/load_scan_state.py
+++ b/skymap_scanner/utils/load_scan_state.py
@@ -156,10 +156,10 @@ def load_GCDQp_state(event_metadata: EventMetadata, filestager=None, cache_dir="
                 for GCD_base_dir in cfg.GCD_BASE_DIRS:
                     try:
                         read_url = os.path.join(GCD_base_dir, source_baseline_GCD_metadata)
-                        LOGGER.debug("reading GCD from {0}".format( read_url ))
+                        LOGGER.debug("load_GCDQp_state => reading GCD from {0}".format( read_url ))
                         GCD_diff_base_handle = filestager.GetReadablePath( read_url )
                         if not os.path.isfile( str(GCD_diff_base_handle) ):
-                            raise RuntimeError("file does not exist (or is not a file)")
+                            raise RuntimeError("load_GCDQp_state => file does not exist (or is not a file)")
                     except:
                         LOGGER.debug(" -> failed")
                         GCD_diff_base_handle=None
@@ -168,7 +168,7 @@ def load_GCDQp_state(event_metadata: EventMetadata, filestager=None, cache_dir="
                         break
                 
                 if GCD_diff_base_handle is None:
-                    raise RuntimeError("Could not read the input GCD file \"{0}\" from any pre-configured location".format(source_baseline_GCD_metadata))
+                    raise RuntimeError("load_GCDQp_state => Could not read the input GCD file \"{0}\" from any pre-configured location".format(source_baseline_GCD_metadata))
 
                 source_baseline_GCD = load_framepacket_from_file( str(GCD_diff_base_handle) )
             this_packet = load_framepacket_from_file(cached_baseline_GCD)
@@ -176,7 +176,7 @@ def load_GCDQp_state(event_metadata: EventMetadata, filestager=None, cache_dir="
             orig_packet_hash = hash_frame_packet(source_baseline_GCD)
             this_packet_hash = hash_frame_packet(this_packet)
             if orig_packet_hash != this_packet_hash:
-                raise RuntimeError("cached GCD baseline file is different from the original file")
+                raise RuntimeError("load_GCDQp_state => cached GCD baseline file is different from the original file")
 
             del source_baseline_GCD
             del this_packet

--- a/skymap_scanner/utils/load_scan_state.py
+++ b/skymap_scanner/utils/load_scan_state.py
@@ -13,7 +13,7 @@ from .. import config as cfg
 from . import LOGGER
 from .event_tools import EventMetadata
 from .pixelreco import PixelReco
-from .utils import hash_frame_packet, load_framepacket_file
+from .utils import hash_frame_packet, load_framepacket_from_file
 
 
 def load_cache_state(
@@ -44,7 +44,7 @@ def get_baseline_gcd_frames(baseline_GCD_file, GCDQp_packet, filestager) -> List
           
         LOGGER.debug(f"Trying to read GCD from {baseline_GCD_file}.")
         try:
-            baseline_GCD_frames = load_framepacket_file(baseline_GCD_file, filestager=filestager)
+            baseline_GCD_frames = load_framepacket_from_file(baseline_GCD_file, filestager=filestager)
         except:
             LOGGER.debug(" -> failed")
             raise RuntimeError("Unable to read baseline GCD. In the current design, this is unexpected. Possibly a bug or data corruption!")
@@ -92,7 +92,7 @@ def load_scan_state(
         pixels = [(int(d[3:-3]), os.path.join(nside_dir, d)) for d in os.listdir(nside_dir) if os.path.isfile(os.path.join(nside_dir, d)) and d.startswith("pix") and d.endswith(".i3")]
 
         for pixel, pixel_file in pixels:
-            loaded_frames = load_framepacket_file(pixel_file)
+            loaded_frames = load_framepacket_from_file(pixel_file)
             if len(loaded_frames) == 0:
                 continue  # skip empty files
             if len(loaded_frames) > 1:
@@ -126,13 +126,13 @@ def load_GCDQp_state(event_metadata: EventMetadata, filestager=None, cache_dir="
     if not os.path.isfile(GCDQp_filename):
         raise RuntimeError("event \"{0}\" not found in cache at \"{1}\".".format(str(event_metadata), GCDQp_filename))
 
-    frame_packet = load_framepacket_file(GCDQp_filename)
+    frame_packet = load_framepacket_from_file(GCDQp_filename)
     LOGGER.debug("loaded frame packet from {0}".format(GCDQp_filename))
 
     if os.path.isfile(potential_GCD_diff_base_filename):
         if potential_original_GCD_diff_base_filename is None:
             # load and throw away to make sure it is readable
-            load_framepacket_file(potential_GCD_diff_base_filename)
+            load_framepacket_from_file(potential_GCD_diff_base_filename)
             LOGGER.debug(" - has a frame diff packet at {0}".format(potential_GCD_diff_base_filename))
             GCD_diff_base_filename = potential_GCD_diff_base_filename
             
@@ -144,7 +144,7 @@ def load_GCDQp_state(event_metadata: EventMetadata, filestager=None, cache_dir="
                     try:
                         read_path = os.path.join(GCD_base_dir, potential_original_GCD_diff_base_filename)
                         LOGGER.debug("reading GCD from {0}".format(read_path))
-                        orig_packet = load_framepacket_file(read_path)
+                        orig_packet = load_framepacket_from_file(read_path)
                     except:
                         LOGGER.debug(" -> failed")
                         orig_packet = None
@@ -170,8 +170,8 @@ def load_GCDQp_state(event_metadata: EventMetadata, filestager=None, cache_dir="
                 if GCD_diff_base_handle is None:
                     raise RuntimeError("Could not read the input GCD file \"{0}\" from any pre-configured location".format(potential_original_GCD_diff_base_filename))
 
-                orig_packet = load_framepacket_file( str(GCD_diff_base_handle) )
-            this_packet = load_framepacket_file(potential_GCD_diff_base_filename)
+                orig_packet = load_framepacket_from_file( str(GCD_diff_base_handle) )
+            this_packet = load_framepacket_from_file(potential_GCD_diff_base_filename)
             
             orig_packet_hash = hash_frame_packet(orig_packet)
             this_packet_hash = hash_frame_packet(this_packet)

--- a/skymap_scanner/utils/load_scan_state.py
+++ b/skymap_scanner/utils/load_scan_state.py
@@ -129,7 +129,7 @@ def load_GCDQp_state(event_metadata: EventMetadata, filestager=None, cache_dir="
     GCDQp_filename = os.path.join(this_event_cache_dir, "GCDQp.i3")
     potential_GCD_diff_base_filename = os.path.join(this_event_cache_dir, cfg.BASELINE_GCD_FILENAME)
 
-    potential_original_GCD_diff_base_filename = os.path.join(this_event_cache_dir, "original_base_GCD_for_diff_filename.txt")
+    potential_original_GCD_diff_base_filename = os.path.join(this_event_cache_dir, cfg.SOURCE_BASELINE_GCD_METADATA)
     if os.path.isfile(potential_original_GCD_diff_base_filename):
         f = open(potential_original_GCD_diff_base_filename, 'r')
         potential_original_GCD_diff_base_filename = f.read()

--- a/skymap_scanner/utils/prepare_frames.py
+++ b/skymap_scanner/utils/prepare_frames.py
@@ -110,6 +110,7 @@ def prepare_frames(frame_array, baseline_GCD, reco_algo, pulsesName="SplitUnclea
         If=lambda frame: nominalPulsesName+'HLC' not in frame)
 
     if reco_algo.lower() == 'millipede_original':
+        # TODO: documentation for this conditional statement
         tray.AddModule('VHESelfVeto', 'selfveto',
                        VertexThreshold=2,
                        Pulses=nominalPulsesName+'HLC',
@@ -143,7 +144,7 @@ def prepare_frames(frame_array, baseline_GCD, reco_algo, pulsesName="SplitUnclea
                 non_diff_key = key[:-4]
                 if non_diff_key in all_keys:
                     del frame[non_diff_key]
-                    # print "deleted", non_diff_key, "from frame because a Diff exists"
+                    LOGGER.debug(f"Deleted {non_diff_key} from frame because a corresponding Diff exists.")
         tray.AddModule(delFrameObjectsWithDiffsAvailable, "delFrameObjectsWithDiffsAvailable", Streams=[icetray.I3Frame.Geometry, icetray.I3Frame.Calibration, icetray.I3Frame.DetectorStatus])
     
     tray.AddModule(FrameArraySink, FrameStore=output_frames)

--- a/skymap_scanner/utils/prepare_frames.py
+++ b/skymap_scanner/utils/prepare_frames.py
@@ -65,7 +65,7 @@ class FrameArraySink(icetray.I3Module):
         
         self.PushFrame(frame)
 
-def prepare_frames(frame_array, GCD_diff_base_filename, reco_algo, pulsesName="SplitUncleanedInIcePulses"):
+def prepare_frames(frame_array, baseline_GCD, reco_algo, pulsesName="SplitUncleanedInIcePulses"):
     from icecube import (
         DomTools,
         VHESelfVeto,
@@ -84,8 +84,8 @@ def prepare_frames(frame_array, GCD_diff_base_filename, reco_algo, pulsesName="S
     tray = I3Tray()
     tray.AddModule(FrameArraySource, Frames=frame_array)
 
-    if GCD_diff_base_filename is not None:
-        base_GCD_path, base_GCD_filename = os.path.split(GCD_diff_base_filename)
+    if baseline_GCD is not None:
+        base_GCD_path, base_GCD_filename = os.path.split(baseline_GCD)
         tray.Add(uncompress, "GCD_uncompress",
                  keep_compressed=True,
                  base_path=base_GCD_path,
@@ -135,7 +135,7 @@ def prepare_frames(frame_array, GCD_diff_base_filename, reco_algo, pulsesName="S
                        OutputVertexPos=cfg.INPUT_POS_NAME,
                        If=lambda frame: not frame.Has("HESE_VHESelfVeto"))
 
-    if GCD_diff_base_filename is not None:
+    if baseline_GCD is not None:
         def delFrameObjectsWithDiffsAvailable(frame):
             all_keys = list(frame.keys())
             for key in list(frame.keys()):

--- a/skymap_scanner/utils/utils.py
+++ b/skymap_scanner/utils/utils.py
@@ -44,7 +44,10 @@ def get_event_mjd(frame_packet: List[icetray.I3Frame]) -> float:
     return time.mod_julian_day_double  # type: ignore[no-any-return]
 
 
-def load_framepacket_file(filename : str, filestager=None) -> List[icetray.I3Frame]:
+def load_framepacket_from_file(filename : str, filestager=None) -> List[icetray.I3Frame]:
+    """
+    Loads an I3 file provided a filename and returns a list of I3Frame objects (frame packet)
+    """
     # Legacy code used to loop over GCD_BASE_DIRS.
     # Now it is assumed that filename points to a valid GCD file.
     if filestager is not None:

--- a/skymap_scanner/utils/utils.py
+++ b/skymap_scanner/utils/utils.py
@@ -44,9 +44,9 @@ def get_event_mjd(frame_packet: List[icetray.I3Frame]) -> float:
     return time.mod_julian_day_double  # type: ignore[no-any-return]
 
 
-def load_GCD_frame_packet_from_file(filename, filestager=None):
+def load_framepacket_file(filename : str, filestager=None) -> List[icetray.I3Frame]:
     # Legacy code used to loop over GCD_BASE_DIRS.
-    # Now it is assumed that filename points to a valid GCD file!
+    # Now it is assumed that filename points to a valid GCD file.
     if filestager is not None:
         read_url_handle = filestager.GetReadablePath( filename )
     else:

--- a/skymap_scanner/utils/utils.py
+++ b/skymap_scanner/utils/utils.py
@@ -45,17 +45,12 @@ def get_event_mjd(frame_packet: List[icetray.I3Frame]) -> float:
 
 
 def load_GCD_frame_packet_from_file(filename, filestager=None):
-    read_url = filename
-    for GCD_base_dir in cfg.GCD_BASE_DIRS:
-        potential_read_url = os.path.join(GCD_base_dir, filename)
-        if os.path.isfile( potential_read_url ):
-            read_url = potential_read_url
-            break
-
+    # Legacy code used to loop over GCD_BASE_DIRS.
+    # Now it is assumed that filename points to a valid GCD file!
     if filestager is not None:
-        read_url_handle = filestager.GetReadablePath( read_url )
+        read_url_handle = filestager.GetReadablePath( filename )
     else:
-        read_url_handle = read_url
+        read_url_handle = filename
 
     frame_packet = []
     i3f = dataio.I3File(str(read_url_handle),'r')
@@ -64,9 +59,6 @@ def load_GCD_frame_packet_from_file(filename, filestager=None):
             return frame_packet
         frame = i3f.pop_frame()
         frame_packet.append(frame)
-
-    del read_url_handle
-
 
 def save_GCD_frame_packet_to_file(
     frame_packet: List[icetray.I3Frame],

--- a/skymap_scanner/utils/utils.py
+++ b/skymap_scanner/utils/utils.py
@@ -44,19 +44,15 @@ def get_event_mjd(frame_packet: List[icetray.I3Frame]) -> float:
     return time.mod_julian_day_double  # type: ignore[no-any-return]
 
 
-def load_framepacket_from_file(filename : str, filestager=None) -> List[icetray.I3Frame]:
+def load_framepacket_from_file(filename : str) -> List[icetray.I3Frame]:
     """
     Loads an I3 file provided a filename and returns a list of I3Frame objects (frame packet)
     """
     # Legacy code used to loop over GCD_BASE_DIRS.
     # Now it is assumed that filename points to a valid GCD file.
-    if filestager is not None:
-        read_url_handle = filestager.GetReadablePath( filename )
-    else:
-        read_url_handle = filename
-
     frame_packet = []
-    i3f = dataio.I3File(str(read_url_handle),'r')
+
+    i3f = dataio.I3File(filename,'r')
     while True:
         if not i3f.more():
             return frame_packet


### PR DESCRIPTION
Up to now:
- removal of the `config.GCD_BASE_DIRS` list, assuming GCD files are always read from the container `DEFAULT_GCD_DIR`;
- simplification of GCD handling in `extract_json_message()` and `load_cache_state()`
- improvement to the naming of variables and functions, in particular `GCD_diff_base_*` is now consistently named `baseline_GCD_*`
- avoid reusing the same variable name for different purposes along the code;
- some hardcoded strings have been parameterized in `config.py`;
- comments and documentation;
- removal of IceTray filestagers for reading GCD files.