### PR TITLE
CI Expediate Steps on `main`

### DIFF
--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -121,7 +121,6 @@ jobs:
           git_committer_email: ${{ env.BOT_EMAIL }}
 
   py-versions:
-    needs: [py-setup]
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.versions.outputs.matrix }}

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -130,7 +130,7 @@ jobs:
         uses: WIPACrepo/wipac-dev-py-versions-action@v2
 
   pip-install:
-    # FUTURE DEV: this can be expanded to run actual tests instead of just pip installing
+    # If this fails, the longer tests are sure to fail
     needs: [py-versions]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -24,7 +24,7 @@ jobs:
   #         python-version: '3.9'
   #     - uses: WIPACrepo/wipac-dev-mypy-action@v1.1
 
-  wait-for-branch-protections-on-main:  # pass always when not on main (don't use 'if' b/c downstream)
+  wait-for-tests-on-main:  # pass always when not on main (don't use 'if' b/c downstream)
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
@@ -106,7 +106,7 @@ jobs:
           '
 
   py-setup:
-    needs: [wait-for-branch-protections-on-main]  # have to wait for tests so wipac-dev-py-setup-action can push (branch protection on main)
+    # needs: [wait-for-tests-on-main]  # NOTE: this would be needed if enabling "all tests to pass" branch protection
     runs-on: ubuntu-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -150,7 +150,7 @@ jobs:
   release:
     # only run on main/master/default
     if: format('refs/heads/{0}', github.event.repository.default_branch) == github.ref
-    needs: [py-setup, pip-install, wait-for-branch-protections-on-main]  # have to wait for tests so python-semantic-release can push (branch protection on main)
+    needs: [py-setup, pip-install, wait-for-tests-on-main]  # have to wait for tests so python-semantic-release can push (branch protection on main)
     runs-on: ubuntu-latest
     concurrency: release
     steps:

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -44,7 +44,7 @@ google-auth==2.16.2
     # via
     #   google-api-core
     #   oms-mqclient
-google-cloud-pubsub==2.15.0
+google-cloud-pubsub==2.15.1
     # via oms-mqclient
 googleapis-common-protos[grpc]==1.58.0
     # via
@@ -120,7 +120,7 @@ protobuf==4.22.1
     #   grpc-google-iam-v1
     #   grpcio-status
     #   proto-plus
-pulsar-client==3.0.0
+pulsar-client==3.1.0
     # via oms-mqclient
 pyasn1==0.4.8
     # via
@@ -172,7 +172,7 @@ typing-extensions==4.5.0
     # via
     #   qrcode
     #   wipac-dev-tools
-urllib3==1.26.14
+urllib3==1.26.15
     # via requests
 wipac-dev-tools[coloredlogs]==1.6.13
     # via

--- a/requirements-client-starter.txt
+++ b/requirements-client-starter.txt
@@ -110,7 +110,7 @@ typing-extensions==4.5.0
     # via
     #   qrcode
     #   wipac-dev-tools
-urllib3==1.26.14
+urllib3==1.26.15
     # via requests
 wipac-dev-tools[coloredlogs]==1.6.13
     # via

--- a/requirements-gcp.txt
+++ b/requirements-gcp.txt
@@ -40,7 +40,7 @@ google-auth==2.16.2
     # via
     #   google-api-core
     #   oms-mqclient
-google-cloud-pubsub==2.15.0
+google-cloud-pubsub==2.15.1
     # via oms-mqclient
 googleapis-common-protos[grpc]==1.58.0
     # via
@@ -160,7 +160,7 @@ typing-extensions==4.5.0
     # via
     #   qrcode
     #   wipac-dev-tools
-urllib3==1.26.14
+urllib3==1.26.15
     # via requests
 wipac-dev-tools[coloredlogs]==1.6.13
     # via

--- a/requirements-nats.txt
+++ b/requirements-nats.txt
@@ -114,7 +114,7 @@ typing-extensions==4.5.0
     # via
     #   qrcode
     #   wipac-dev-tools
-urllib3==1.26.14
+urllib3==1.26.15
     # via requests
 wipac-dev-tools[coloredlogs]==1.6.13
     # via

--- a/requirements-pulsar.txt
+++ b/requirements-pulsar.txt
@@ -71,7 +71,7 @@ pandas==1.5.3
     # via skymap-scanner (setup.py)
 pillow==9.4.0
     # via matplotlib
-pulsar-client==3.0.0
+pulsar-client==3.1.0
     # via oms-mqclient
 pycparser==2.21
     # via cffi
@@ -112,7 +112,7 @@ typing-extensions==4.5.0
     # via
     #   qrcode
     #   wipac-dev-tools
-urllib3==1.26.14
+urllib3==1.26.15
     # via requests
 wipac-dev-tools[coloredlogs]==1.6.13
     # via

--- a/requirements-rabbitmq.txt
+++ b/requirements-rabbitmq.txt
@@ -110,7 +110,7 @@ typing-extensions==4.5.0
     # via
     #   qrcode
     #   wipac-dev-tools
-urllib3==1.26.14
+urllib3==1.26.15
     # via requests
 wipac-dev-tools[coloredlogs]==1.6.13
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -108,7 +108,7 @@ typing-extensions==4.5.0
     # via
     #   qrcode
     #   wipac-dev-tools
-urllib3==1.26.14
+urllib3==1.26.15
     # via requests
 wipac-dev-tools[coloredlogs]==1.6.13
     # via


### PR DESCRIPTION
Now, `py-setup`, `py-versions`, and `pip-install` will start before the tests are finished on `main`. The performance increase is minimal in the typical case, but we'll see more :heavy_check_mark:s sooner. In the best case, `py-setup` will auto-push and save ~40 mins.