### PR TITLE
Track subevents when converting i3 to json 

### DIFF
--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=all --output-file=requirements-all.txt
 #
-astropy==5.2.2
+astropy==5.2.1
     # via
     #   healpy
     #   skymap-scanner (setup.py)
@@ -40,7 +40,7 @@ google-api-core[grpc]==2.11.0
     # via
     #   google-cloud-pubsub
     #   oms-mqclient
-google-auth==2.16.3
+google-auth==2.17.0
     # via
     #   google-api-core
     #   oms-mqclient

--- a/requirements-client-starter.txt
+++ b/requirements-client-starter.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=client-starter --output-file=requirements-client-starter.txt
 #
-astropy==5.2.2
+astropy==5.2.1
     # via
     #   healpy
     #   skymap-scanner (setup.py)

--- a/requirements-gcp.txt
+++ b/requirements-gcp.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=gcp --output-file=requirements-gcp.txt
 #
-astropy==5.2.2
+astropy==5.2.1
     # via
     #   healpy
     #   skymap-scanner (setup.py)
@@ -36,7 +36,7 @@ google-api-core[grpc]==2.11.0
     # via
     #   google-cloud-pubsub
     #   oms-mqclient
-google-auth==2.16.3
+google-auth==2.17.0
     # via
     #   google-api-core
     #   oms-mqclient

--- a/requirements-nats.txt
+++ b/requirements-nats.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=nats --output-file=requirements-nats.txt
 #
-astropy==5.2.2
+astropy==5.2.1
     # via
     #   healpy
     #   skymap-scanner (setup.py)

--- a/requirements-pulsar.txt
+++ b/requirements-pulsar.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=pulsar --output-file=requirements-pulsar.txt
 #
-astropy==5.2.2
+astropy==5.2.1
     # via
     #   healpy
     #   skymap-scanner (setup.py)

--- a/requirements-rabbitmq.txt
+++ b/requirements-rabbitmq.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=rabbitmq --output-file=requirements-rabbitmq.txt
 #
-astropy==5.2.2
+astropy==5.2.1
     # via
     #   healpy
     #   skymap-scanner (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt
 #
-astropy==5.2.2
+astropy==5.2.1
     # via
     #   healpy
     #   skymap-scanner (setup.py)


### PR DESCRIPTION
Since the inice split is rerun there can be multiple subevents that don't exist in the input stream. Save only those present in the input stream.