### PR TITLE
Trim Logging of Large Objects

### DIFF
--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -106,7 +106,7 @@ pyyaml==6.0
     # via astropy
 qrcode==7.4.2
     # via wipac-rest-tools
-requests==2.29.0
+requests==2.30.0
     # via
     #   requests-futures
     #   wipac-dev-tools
@@ -127,7 +127,7 @@ typing-extensions==4.5.0
     #   wipac-dev-tools
 tzdata==2023.3
     # via pandas
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 wipac-dev-tools[coloredlogs]==1.6.15
     # via

--- a/requirements-client-starter.txt
+++ b/requirements-client-starter.txt
@@ -96,7 +96,7 @@ pyyaml==6.0
     # via astropy
 qrcode==7.4.2
     # via wipac-rest-tools
-requests==2.29.0
+requests==2.30.0
     # via
     #   requests-futures
     #   wipac-dev-tools
@@ -117,7 +117,7 @@ typing-extensions==4.5.0
     #   wipac-dev-tools
 tzdata==2023.3
     # via pandas
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 wipac-dev-tools[coloredlogs]==1.6.15
     # via

--- a/requirements-nats.txt
+++ b/requirements-nats.txt
@@ -100,7 +100,7 @@ pyyaml==6.0
     # via astropy
 qrcode==7.4.2
     # via wipac-rest-tools
-requests==2.29.0
+requests==2.30.0
     # via
     #   requests-futures
     #   wipac-dev-tools
@@ -121,7 +121,7 @@ typing-extensions==4.5.0
     #   wipac-dev-tools
 tzdata==2023.3
     # via pandas
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 wipac-dev-tools[coloredlogs]==1.6.15
     # via

--- a/requirements-pulsar.txt
+++ b/requirements-pulsar.txt
@@ -98,7 +98,7 @@ pyyaml==6.0
     # via astropy
 qrcode==7.4.2
     # via wipac-rest-tools
-requests==2.29.0
+requests==2.30.0
     # via
     #   requests-futures
     #   wipac-dev-tools
@@ -119,7 +119,7 @@ typing-extensions==4.5.0
     #   wipac-dev-tools
 tzdata==2023.3
     # via pandas
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 wipac-dev-tools[coloredlogs]==1.6.15
     # via

--- a/requirements-rabbitmq.txt
+++ b/requirements-rabbitmq.txt
@@ -96,7 +96,7 @@ pyyaml==6.0
     # via astropy
 qrcode==7.4.2
     # via wipac-rest-tools
-requests==2.29.0
+requests==2.30.0
     # via
     #   requests-futures
     #   wipac-dev-tools
@@ -117,7 +117,7 @@ typing-extensions==4.5.0
     #   wipac-dev-tools
 tzdata==2023.3
     # via pandas
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 wipac-dev-tools[coloredlogs]==1.6.15
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -94,7 +94,7 @@ pyyaml==6.0
     # via astropy
 qrcode==7.4.2
     # via wipac-rest-tools
-requests==2.29.0
+requests==2.30.0
     # via
     #   requests-futures
     #   wipac-dev-tools
@@ -115,7 +115,7 @@ typing-extensions==4.5.0
     #   wipac-dev-tools
 tzdata==2023.3
     # via pandas
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 wipac-dev-tools[coloredlogs]==1.6.15
     # via

--- a/skymap_scanner/server/collector.py
+++ b/skymap_scanner/server/collector.py
@@ -222,7 +222,7 @@ class Collector:
         if not self._in_finder_context:
             raise RuntimeError("Must be in `Collector.finder_context()` context.")
         LOGGER.debug(  # don't log HUGE string
-            f"self.nsides_dict info: {(k,len(v)) for k, v in self.nsides_dict.items()}"
+            f"self.nsides_dict info: {[(k,len(v)) for k, v in self.nsides_dict.items()]}"
         )
 
         if reco_pixel_variation.id_tuple in self._pixfinid_received_quick_lookup:

--- a/skymap_scanner/server/collector.py
+++ b/skymap_scanner/server/collector.py
@@ -222,7 +222,7 @@ class Collector:
         if not self._in_finder_context:
             raise RuntimeError("Must be in `Collector.finder_context()` context.")
         LOGGER.debug(  # don't log HUGE string
-            f"self.nsides_dict info: {[(k,len(v)) for k, v in self.nsides_dict.items()]}"
+            f"self.nsides_dict info (# pixels per nside): {[(k,len(v)) for k, v in self.nsides_dict.items()]}"
         )
 
         if reco_pixel_variation.id_tuple in self._pixfinid_received_quick_lookup:

--- a/skymap_scanner/server/collector.py
+++ b/skymap_scanner/server/collector.py
@@ -221,7 +221,9 @@ class Collector:
         reco (RecoPixelFinal)."""
         if not self._in_finder_context:
             raise RuntimeError("Must be in `Collector.finder_context()` context.")
-        LOGGER.debug(f"{self.nsides_dict=}")
+        LOGGER.debug(  # don't log HUGE string
+            f"self.nsides_dict info: {(k,len(v)) for k, v in self.nsides_dict.items()}"
+        )
 
         if reco_pixel_variation.id_tuple in self._pixfinid_received_quick_lookup:
             raise ExtraRecoPixelVariationException(

--- a/skymap_scanner/server/reporter.py
+++ b/skymap_scanner/server/reporter.py
@@ -599,7 +599,7 @@ class Reporter:
         serialized = result.serialize()
 
         LOGGER.debug(  # don't log HUGE string
-            f"Result info (# pixels per nside): {(k, len(v)) for k, v in result.result.items()}"
+            f"Result info (# pixels per nside): {[(k, len(v)) for k, v in result.result.items()]}"
         )
         if not self.skydriver_rc:
             return result

--- a/skymap_scanner/server/reporter.py
+++ b/skymap_scanner/server/reporter.py
@@ -598,9 +598,9 @@ class Reporter:
         result = self._get_result()
         serialized = result.serialize()
 
-        LOGGER.debug(pyobj_to_string_repr(serialized))
-        lens = {k: len(v) for k, v in result.result.items()}
-        LOGGER.debug(f"Result info (# pixels per nside): {lens}")
+        LOGGER.debug(  # don't log HUGE string
+            f"Result info (# pixels per nside): {(k, len(v)) for k, v in result.result.items()}"
+        )
         if not self.skydriver_rc:
             return result
 

--- a/skymap_scanner/server/reporter.py
+++ b/skymap_scanner/server/reporter.py
@@ -599,6 +599,8 @@ class Reporter:
         serialized = result.serialize()
 
         LOGGER.debug(pyobj_to_string_repr(serialized))
+        lens = {k: len(v) for k, v in result.result.items()}
+        LOGGER.debug(f"Result info (# pixels per nside): {lens}")
         if not self.skydriver_rc:
             return result
 


### PR DESCRIPTION
Don't log the nsides dict / result object in their entirety--they're very large

For skydriver cases, they're sent over the wire. For manual running events, a json file is written on a successful exit