### PR TITLE
Decouple spline staging from class declaration

### DIFF
--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -117,7 +117,7 @@ scipy==1.10.1
     # via healpy
 six==1.16.0
     # via python-dateutil
-tornado==6.3.1
+tornado==6.3.2
     # via wipac-rest-tools
 types-cryptography==3.3.23.2
     # via pyjwt

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -10,7 +10,7 @@ astropy==5.2.2
     #   icecube-skyreader
 cachetools==5.3.0
     # via wipac-rest-tools
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   pulsar-client
     #   requests
@@ -28,9 +28,9 @@ cycler==0.11.0
     # via matplotlib
 ed25519==1.5
     # via nkeys
-ewms-pilot==0.10.0
+ewms-pilot==0.10.2
     # via skymap-scanner (setup.py)
-fonttools==4.39.3
+fonttools==4.39.4
     # via matplotlib
 healpy==1.16.2
     # via
@@ -80,7 +80,7 @@ packaging==23.1
     #   matplotlib
 pandas==2.0.1
     # via icecube-skyreader
-pika==1.3.1
+pika==1.3.2
     # via oms-mqclient
 pillow==9.5.0
     # via matplotlib

--- a/requirements-client-starter.txt
+++ b/requirements-client-starter.txt
@@ -10,7 +10,7 @@ astropy==5.2.2
     #   icecube-skyreader
 cachetools==5.3.0
     # via wipac-rest-tools
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 cffi==1.15.1
     # via cryptography
@@ -24,9 +24,9 @@ cryptography==40.0.2
     # via pyjwt
 cycler==0.11.0
     # via matplotlib
-ewms-pilot==0.10.0
+ewms-pilot==0.10.2
     # via skymap-scanner (setup.py)
-fonttools==4.39.3
+fonttools==4.39.4
     # via matplotlib
 healpy==1.16.2
     # via

--- a/requirements-client-starter.txt
+++ b/requirements-client-starter.txt
@@ -107,7 +107,7 @@ scipy==1.10.1
     # via healpy
 six==1.16.0
     # via python-dateutil
-tornado==6.3.1
+tornado==6.3.2
     # via wipac-rest-tools
 types-cryptography==3.3.23.2
     # via pyjwt

--- a/requirements-nats.txt
+++ b/requirements-nats.txt
@@ -111,7 +111,7 @@ scipy==1.10.1
     # via healpy
 six==1.16.0
     # via python-dateutil
-tornado==6.3.1
+tornado==6.3.2
     # via wipac-rest-tools
 types-cryptography==3.3.23.2
     # via pyjwt

--- a/requirements-nats.txt
+++ b/requirements-nats.txt
@@ -10,7 +10,7 @@ astropy==5.2.2
     #   icecube-skyreader
 cachetools==5.3.0
     # via wipac-rest-tools
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 cffi==1.15.1
     # via cryptography
@@ -26,9 +26,9 @@ cycler==0.11.0
     # via matplotlib
 ed25519==1.5
     # via nkeys
-ewms-pilot==0.10.0
+ewms-pilot==0.10.2
     # via skymap-scanner (setup.py)
-fonttools==4.39.3
+fonttools==4.39.4
     # via matplotlib
 healpy==1.16.2
     # via

--- a/requirements-pulsar.txt
+++ b/requirements-pulsar.txt
@@ -109,7 +109,7 @@ scipy==1.10.1
     # via healpy
 six==1.16.0
     # via python-dateutil
-tornado==6.3.1
+tornado==6.3.2
     # via wipac-rest-tools
 types-cryptography==3.3.23.2
     # via pyjwt

--- a/requirements-pulsar.txt
+++ b/requirements-pulsar.txt
@@ -10,7 +10,7 @@ astropy==5.2.2
     #   icecube-skyreader
 cachetools==5.3.0
     # via wipac-rest-tools
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   pulsar-client
     #   requests
@@ -26,9 +26,9 @@ cryptography==40.0.2
     # via pyjwt
 cycler==0.11.0
     # via matplotlib
-ewms-pilot==0.10.0
+ewms-pilot==0.10.2
     # via skymap-scanner (setup.py)
-fonttools==4.39.3
+fonttools==4.39.4
     # via matplotlib
 healpy==1.16.2
     # via

--- a/requirements-rabbitmq.txt
+++ b/requirements-rabbitmq.txt
@@ -10,7 +10,7 @@ astropy==5.2.2
     #   icecube-skyreader
 cachetools==5.3.0
     # via wipac-rest-tools
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 cffi==1.15.1
     # via cryptography
@@ -24,9 +24,9 @@ cryptography==40.0.2
     # via pyjwt
 cycler==0.11.0
     # via matplotlib
-ewms-pilot==0.10.0
+ewms-pilot==0.10.2
     # via skymap-scanner (setup.py)
-fonttools==4.39.3
+fonttools==4.39.4
     # via matplotlib
 healpy==1.16.2
     # via
@@ -72,7 +72,7 @@ packaging==23.1
     #   matplotlib
 pandas==2.0.1
     # via icecube-skyreader
-pika==1.3.1
+pika==1.3.2
     # via oms-mqclient
 pillow==9.5.0
     # via matplotlib

--- a/requirements-rabbitmq.txt
+++ b/requirements-rabbitmq.txt
@@ -107,7 +107,7 @@ scipy==1.10.1
     # via healpy
 six==1.16.0
     # via python-dateutil
-tornado==6.3.1
+tornado==6.3.2
     # via wipac-rest-tools
 types-cryptography==3.3.23.2
     # via pyjwt

--- a/requirements.txt
+++ b/requirements.txt
@@ -105,7 +105,7 @@ scipy==1.10.1
     # via healpy
 six==1.16.0
     # via python-dateutil
-tornado==6.3.1
+tornado==6.3.2
     # via wipac-rest-tools
 types-cryptography==3.3.23.2
     # via pyjwt

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ astropy==5.2.2
     #   icecube-skyreader
 cachetools==5.3.0
     # via wipac-rest-tools
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 cffi==1.15.1
     # via cryptography
@@ -24,9 +24,9 @@ cryptography==40.0.2
     # via pyjwt
 cycler==0.11.0
     # via matplotlib
-ewms-pilot==0.10.0
+ewms-pilot==0.10.2
     # via skymap-scanner (setup.py)
-fonttools==4.39.3
+fonttools==4.39.4
     # via matplotlib
 healpy==1.16.2
     # via

--- a/skymap_scanner/client/reco_icetray.py
+++ b/skymap_scanner/client/reco_icetray.py
@@ -139,9 +139,13 @@ def reco_pixel(
             base_filename=baseline_GCD_file,
         )
 
+    # create instance of reco_algo object
+    RecoAlgo = recos.get_reco_interface_object(reco_algo)
+    reco = RecoAlgo()
+
     # perform fit
     tray.AddSegment(
-        recos.get_reco_interface_object(reco_algo).traysegment,
+        reco.traysegment,
         f"{reco_algo}_traysegment",
         logger=LOGGER,
         seed=pframe[f"{cfg.OUTPUT_PARTICLE_NAME}"],

--- a/skymap_scanner/client/reco_icetray.py
+++ b/skymap_scanner/client/reco_icetray.py
@@ -142,6 +142,7 @@ def reco_pixel(
     # create instance of reco_algo object
     RecoAlgo = recos.get_reco_interface_object(reco_algo)
     reco = RecoAlgo()
+    reco.setup_reco()
 
     # perform fit
     tray.AddSegment(

--- a/skymap_scanner/recos/__init__.py
+++ b/skymap_scanner/recos/__init__.py
@@ -31,6 +31,21 @@ class RecoInterface:
     # The spline files will be looked up in pre-defined local paths or fetched from a remote data store.
     SPLINE_REQUIREMENTS: List[str] = list()
 
+    def init(self):
+        raise NotImplementedError()
+
+    def setup_reco(self):
+        """Performs the necessary operations to prepare the execution of the reconstruction traysegment."""
+        raise NotImplementedError()
+
+    def get_datastager(self):
+        datastager = DataStager(
+            local_paths=cfg.LOCAL_DATA_SOURCES,
+            local_subdir=cfg.LOCAL_SPLINE_SUBDIR,
+            remote_path=f"{cfg.REMOTE_DATA_SOURCE}/{cfg.REMOTE_SPLINE_SUBDIR}",
+        )
+        return datastager
+
     @staticmethod
     def traysegment(tray, name, logger, **kwargs: Any) -> None:
         raise NotImplementedError()
@@ -49,7 +64,7 @@ def get_all_reco_algos() -> List[str]:
     ]
 
 
-def get_reco_interface_object(name: str) -> RecoInterface:
+def get_reco_interface_object(name: str) -> type[RecoInterface]:
     """Dynamically import the reco sub-module's class."""
     try:
         # Fetch module

--- a/skymap_scanner/recos/__init__.py
+++ b/skymap_scanner/recos/__init__.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, List
 if TYPE_CHECKING:  # https://stackoverflow.com/a/65265627
     from ..utils.pixel_classes import RecoPixelVariation
 
+import ..config as cfg
 from ..utils.data_handling import DataStager
 
 try:  # these are only used for typehints, so mock imports are fine

--- a/skymap_scanner/recos/__init__.py
+++ b/skymap_scanner/recos/__init__.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, List
 if TYPE_CHECKING:  # https://stackoverflow.com/a/65265627
     from ..utils.pixel_classes import RecoPixelVariation
 
-import ..config as cfg
+from .. import config as cfg
 from ..utils.data_handling import DataStager
 
 try:  # these are only used for typehints, so mock imports are fine

--- a/skymap_scanner/recos/__init__.py
+++ b/skymap_scanner/recos/__init__.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Any, List
 if TYPE_CHECKING:  # https://stackoverflow.com/a/65265627
     from ..utils.pixel_classes import RecoPixelVariation
 
+from ..utils.data_handling import DataStager
+
 try:  # these are only used for typehints, so mock imports are fine
     from icecube.dataclasses import I3Position  # type: ignore[import]
     from icecube.icetray import I3Frame  # type: ignore[import]

--- a/skymap_scanner/recos/__init__.py
+++ b/skymap_scanner/recos/__init__.py
@@ -54,8 +54,7 @@ def get_reco_interface_object(name: str) -> RecoInterface:
     try:
         # Fetch module
         module = importlib.import_module(f"{__name__}.{name.lower()}")
-        # Build the class name (i.e. reco_algo -> RecoAlgo).
-        return getattr(module, "".join(x.capitalize() for x in name.split("_")))
+        return module.RECO_CLASS
     except ModuleNotFoundError as e:
         if name not in get_all_reco_algos():
             # checking this in 'except' allows us to use 'from e'

--- a/skymap_scanner/recos/dummy.py
+++ b/skymap_scanner/recos/dummy.py
@@ -28,6 +28,12 @@ from . import RecoInterface
 class Dummy(RecoInterface):
     """Logic for a dummy reco."""
 
+    def __init__(self):
+        pass
+
+    def setup_reco(self):
+        pass
+
     @staticmethod
     @icetray.traysegment
     def traysegment(tray, name, logger, **kwargs):

--- a/skymap_scanner/recos/dummy.py
+++ b/skymap_scanner/recos/dummy.py
@@ -22,6 +22,7 @@ from icecube.icetray import I3Frame  # type: ignore[import]
 
 from .. import config as cfg
 from ..utils.pixel_classes import RecoPixelVariation
+from ..utils.data_handling import DataStager
 from . import RecoInterface
 
 

--- a/skymap_scanner/recos/dummy.py
+++ b/skymap_scanner/recos/dummy.py
@@ -22,7 +22,6 @@ from icecube.icetray import I3Frame  # type: ignore[import]
 
 from .. import config as cfg
 from ..utils.pixel_classes import RecoPixelVariation
-from ..utils.data_handling import DataStager
 from . import RecoInterface
 
 

--- a/skymap_scanner/recos/dummy.py
+++ b/skymap_scanner/recos/dummy.py
@@ -4,7 +4,7 @@
 import datetime
 import random
 import time
-from typing import List
+from typing import List, Final
 
 from I3Tray import I3Units  # type: ignore[import]
 from icecube import (  # type: ignore[import]  # noqa: F401
@@ -69,3 +69,7 @@ class Dummy(RecoInterface):
             time=frame["Dummy_time"].value,
             energy=frame["Dummy_time"].value,
         )
+
+
+# Provide a standard alias for the reconstruction class provided by this module.
+RECO_CLASS: Final[type[RecoInterface]] = Dummy

--- a/skymap_scanner/recos/millipede_original.py
+++ b/skymap_scanner/recos/millipede_original.py
@@ -254,9 +254,10 @@ class MillipedeOriginal(RecoInterface):
 
         tray.AddModule(notify2, "notify2")
 
-    def to_recopixelvariation(self, frame: I3Frame, geometry: I3Frame) -> RecoPixelVariation:
+    @classmethod
+    def to_recopixelvariation(cls, frame: I3Frame, geometry: I3Frame) -> RecoPixelVariation:
         # Calculate reco losses, based on load_scan_state()
-        reco_losses_inside, reco_losses_total = self.get_reco_losses_inside(
+        reco_losses_inside, reco_losses_total = cls.get_reco_losses_inside(
             p_frame=frame, g_frame=geometry,
         )
 

--- a/skymap_scanner/recos/millipede_original.py
+++ b/skymap_scanner/recos/millipede_original.py
@@ -35,7 +35,7 @@ from . import RecoInterface
 
 class MillipedeOriginal(RecoInterface):
     """Reco logic for millipede."""
-    # Spline requirements
+    # Spline requirements ##############################################
     MIE_ABS_SPLINE = "ems_mie_z20_a10.abs.fits"
     MIE_PROB_SPLINE = "ems_mie_z20_a10.prob.fits"
 
@@ -44,24 +44,28 @@ class MillipedeOriginal(RecoInterface):
     # Constants ########################################################
     pulsesName = cfg.INPUT_PULSES_NAME
     pulsesName_cleaned = pulsesName+'LatePulseCleaned'
-    SPEScale = 0.99
 
     # Load Data ########################################################
     # At HESE energies, deposited light is dominated by the stochastic losses
     # (muon part emits so little light in comparison)
     # This is why we can use cascade tables
-    datastager = DataStager(
-        local_paths=cfg.LOCAL_DATA_SOURCES,
-        local_subdir=cfg.LOCAL_SPLINE_SUBDIR,
-        remote_path=f"{cfg.REMOTE_DATA_SOURCE}/{cfg.REMOTE_SPLINE_SUBDIR}",
-    )
-    datastager.stage_files(SPLINE_REQUIREMENTS)
-    abs_spline: str = datastager.get_filepath(MIE_ABS_SPLINE)
-    prob_spline: str = datastager.get_filepath(MIE_PROB_SPLINE)
 
-    cascade_service = photonics_service.I3PhotoSplineService(abs_spline, prob_spline, timingSigma=0.0)
-    cascade_service.SetEfficiencies(SPEScale)
-    muon_service = None
+    @staticmethod
+    def init_datastager() -> DataStager:
+        """Create datastager, stage spline data and return datastager.
+
+        Returns:
+            DataStager: datastager for spline data.
+        """
+        datastager = DataStager(
+            local_paths=cfg.LOCAL_DATA_SOURCES,
+            local_subdir=cfg.LOCAL_SPLINE_SUBDIR,
+            remote_path=f"{cfg.REMOTE_DATA_SOURCE}/{cfg.REMOTE_SPLINE_SUBDIR}",
+        )
+
+        datastager.stage_files(MillipedeOriginal.SPLINE_REQUIREMENTS)
+
+        return datastager
     
     def makeSurePulsesExist(frame, pulsesName) -> None:
         if pulsesName not in frame:
@@ -159,9 +163,20 @@ class MillipedeOriginal(RecoInterface):
         return ExcludedDOMs + [MillipedeOriginal.pulsesName_cleaned+'TimeWindows']
 
 
+    @staticmethod
     @icetray.traysegment
     def traysegment(tray, name, logger, seed=None):
         """Perform MillipedeOriginal reco."""
+        datastager = MillipedeOriginal.init_datastager()
+
+        abs_spline = datastager.get_filepath(MIE_ABS_SPLINE)
+        prob_spline = datastager.get_filepath(MIE_PROB_SPLINE)   
+
+        cascade_service = photonics_service.I3PhotoSplineService(abs_spline, prob_spline, timingSigma=0.0)
+        SPEScale = 0.99 # moved from MillipedeLikelihoodFactory parameter DOMEfficiency=SPEScale
+        cascade_service.SetEfficiencies(SPEScale)
+        muon_service = None
+
         ExcludedDOMs = tray.Add(MillipedeOriginal.exclusions)
 
         tray.Add(MillipedeOriginal.makeSurePulsesExist, pulsesName=MillipedeOriginal.pulsesName_cleaned)
@@ -172,11 +187,10 @@ class MillipedeOriginal(RecoInterface):
         tray.AddModule(notify0, "notify0")
 
         tray.AddService('MillipedeLikelihoodFactory', 'millipedellh',
-            MuonPhotonicsService=MillipedeOriginal.muon_service,
-            CascadePhotonicsService=MillipedeOriginal.cascade_service,
+            MuonPhotonicsService=muon_service,
+            CascadePhotonicsService=cascade_service,
             ShowerRegularization=0,
             PhotonsPerBin=15,
-            # DOMEfficiency=SPEScale, # moved to cascade_service.SetEfficiencies(SPEScale)
             ExcludedDOMs=ExcludedDOMs,
             PartialExclusion=True,
             ReadoutWindow=MillipedeOriginal.pulsesName_cleaned+'TimeRange',

--- a/skymap_scanner/recos/millipede_original.py
+++ b/skymap_scanner/recos/millipede_original.py
@@ -254,8 +254,7 @@ class MillipedeOriginal(RecoInterface):
 
         tray.AddModule(notify2, "notify2")
 
-    @staticmethod
-    def to_recopixelvariation(frame: I3Frame, geometry: I3Frame) -> RecoPixelVariation:
+    def to_recopixelvariation(self, frame: I3Frame, geometry: I3Frame) -> RecoPixelVariation:
         # Calculate reco losses, based on load_scan_state()
         reco_losses_inside, reco_losses_total = self.get_reco_losses_inside(
             p_frame=frame, g_frame=geometry,

--- a/skymap_scanner/recos/millipede_original.py
+++ b/skymap_scanner/recos/millipede_original.py
@@ -341,3 +341,6 @@ class MillipedeOriginal(RecoInterface):
             totalRecoLossesInside += entry[1]
 
         return totalRecoLossesInside, totalRecoLosses
+
+# Provide a standard alias for the reconstruction class provided by this module.
+RECO_CLASS: Final[type[RecoInterface]] = MillipedeOriginal

--- a/skymap_scanner/recos/millipede_original.py
+++ b/skymap_scanner/recos/millipede_original.py
@@ -169,8 +169,8 @@ class MillipedeOriginal(RecoInterface):
         """Perform MillipedeOriginal reco."""
         datastager = MillipedeOriginal.init_datastager()
 
-        abs_spline = datastager.get_filepath(MIE_ABS_SPLINE)
-        prob_spline = datastager.get_filepath(MIE_PROB_SPLINE)   
+        abs_spline = datastager.get_filepath(MillipedeOriginal.MIE_ABS_SPLINE)
+        prob_spline = datastager.get_filepath(MillipedeOriginal.MIE_PROB_SPLINE)   
 
         cascade_service = photonics_service.I3PhotoSplineService(abs_spline, prob_spline, timingSigma=0.0)
         SPEScale = 0.99 # moved from MillipedeLikelihoodFactory parameter DOMEfficiency=SPEScale

--- a/skymap_scanner/recos/millipede_original.py
+++ b/skymap_scanner/recos/millipede_original.py
@@ -7,7 +7,7 @@
 import copy
 import datetime
 import os
-from typing import Tuple
+from typing import Final, Tuple
 
 import numpy
 

--- a/skymap_scanner/recos/millipede_original.py
+++ b/skymap_scanner/recos/millipede_original.py
@@ -77,19 +77,19 @@ class MillipedeOriginal(RecoInterface):
         if pulsesName + "TimeRange" not in frame:
             raise RuntimeError("{0} not in frame".format(pulsesName + "TimeRange"))
 
-    @staticmethod
+    @classmethod
     @icetray.traysegment
-    def exclusions(tray, name):
+    def exclusions(cls, tray, name):
         tray.Add('Delete', keys=['BrightDOMs',
                                  'SaturatedDOMs',
                                  'DeepCoreDOMs',
-                                 MillipedeOriginal.pulsesName_cleaned,
-                                 MillipedeOriginal.pulsesName_cleaned+'TimeWindows',
-                                 MillipedeOriginal.pulsesName_cleaned+'TimeRange'])
+                                 cls.pulsesName_cleaned,
+                                 cls.pulsesName_cleaned+'TimeWindows',
+                                 cls.pulsesName_cleaned+'TimeRange'])
 
         exclusionList = \
         tray.AddSegment(millipede.HighEnergyExclusions, 'millipede_DOM_exclusions',
-            Pulses = MillipedeOriginal.pulsesName,
+            Pulses = cls.pulsesName,
             ExcludeDeepCore='DeepCoreDOMs',
             ExcludeSaturatedDOMs='SaturatedDOMs',
             ExcludeBrightDOMs='BrightDOMs',
@@ -156,14 +156,14 @@ class MillipedeOriginal(RecoInterface):
                         mask.set(omkey, p, False)
                         counter += 1
                         charge += p.charge
-            frame[MillipedeOriginal.pulsesName_cleaned] = mask
-            frame[MillipedeOriginal.pulsesName_cleaned+"TimeWindows"] = times
-            frame[MillipedeOriginal.pulsesName_cleaned+"TimeRange"] = copy.deepcopy(frame[Pulses+"TimeRange"])
+            frame[cls.pulsesName_cleaned] = mask
+            frame[cls.pulsesName_cleaned+"TimeWindows"] = times
+            frame[cls.pulsesName_cleaned+"TimeRange"] = copy.deepcopy(frame[Pulses+"TimeRange"])
 
         tray.AddModule(LatePulseCleaning, "LatePulseCleaning",
-                       Pulses=MillipedeOriginal.pulsesName,
+                       Pulses=cls.pulsesName,
                        )
-        return ExcludedDOMs + [MillipedeOriginal.pulsesName_cleaned+'TimeWindows']
+        return ExcludedDOMs + [cls.pulsesName_cleaned+'TimeWindows']
 
 
     @icetray.traysegment

--- a/skymap_scanner/recos/millipede_wilks.py
+++ b/skymap_scanner/recos/millipede_wilks.py
@@ -7,7 +7,7 @@
 import copy
 import datetime
 import os
-from typing import Tuple
+from typing import Final, Tuple
 
 import numpy
 from I3Tray import I3Units

--- a/skymap_scanner/recos/millipede_wilks.py
+++ b/skymap_scanner/recos/millipede_wilks.py
@@ -75,19 +75,19 @@ class MillipedeWilks(RecoInterface):
         if pulsesName + "TimeRange" not in frame:
             raise RuntimeError("{0} not in frame".format(pulsesName + "TimeRange"))
 
-    @staticmethod
+    @classmethod
     @icetray.traysegment
-    def exclusions(tray, name):
+    def exclusions(cls, tray, name):
         tray.Add('Delete', keys=['BrightDOMs',
                                  'SaturatedDOMs',
                                  'DeepCoreDOMs',
-                                 MillipedeWilks.pulsesName_cleaned,
-                                 MillipedeWilks.pulsesName_cleaned+'TimeWindows',
-                                 MillipedeWilks.pulsesName_cleaned+'TimeRange'])
+                                 cls.pulsesName_cleaned,
+                                 cls.pulsesName_cleaned+'TimeWindows',
+                                 cls.pulsesName_cleaned+'TimeRange'])
 
         exclusionList = \
         tray.AddSegment(millipede.HighEnergyExclusions, 'millipede_DOM_exclusions',
-            Pulses = MillipedeWilks.pulsesName,
+            Pulses = cls.pulsesName,
             ExcludeDeepCore='DeepCoreDOMs',
             ExcludeSaturatedDOMs='SaturatedDOMs',
             ExcludeBrightDOMs='BrightDOMs',
@@ -128,7 +128,7 @@ class MillipedeWilks(RecoInterface):
 
             frame[output] = unhits
 
-        tray.Add(skipunhits, output='OtherUnhits', pulses=MillipedeWilks.pulsesName)
+        tray.Add(skipunhits, output='OtherUnhits', pulses=cls.pulsesName)
         ExcludedDOMs.append('OtherUnhits')
 
         ##################
@@ -178,14 +178,14 @@ class MillipedeWilks(RecoInterface):
                         mask.set(omkey, p, False)
                         counter += 1
                         charge += p.charge
-            frame[MillipedeWilks.pulsesName_cleaned] = mask
-            frame[MillipedeWilks.pulsesName_cleaned+"TimeWindows"] = times
-            frame[MillipedeWilks.pulsesName_cleaned+"TimeRange"] = copy.deepcopy(frame[MillipedeWilks.pulsesName_orig+"TimeRange"])
+            frame[cls.pulsesName_cleaned] = mask
+            frame[cls.pulsesName_cleaned+"TimeWindows"] = times
+            frame[cls.pulsesName_cleaned+"TimeRange"] = copy.deepcopy(frame[cls.pulsesName_orig+"TimeRange"])
 
         tray.AddModule(LatePulseCleaning, "LatePulseCleaning",
-                       Pulses=MillipedeWilks.pulsesName,
+                       Pulses=cls.pulsesName,
                        )
-        return ExcludedDOMs + [MillipedeWilks.pulsesName_cleaned+'TimeWindows']
+        return ExcludedDOMs + [cls.pulsesName_cleaned+'TimeWindows']
 
     @icetray.traysegment
     def traysegment(self, tray, name, logger, seed=None):

--- a/skymap_scanner/recos/millipede_wilks.py
+++ b/skymap_scanner/recos/millipede_wilks.py
@@ -31,8 +31,6 @@ from ..utils.data_handling import DataStager
 from ..utils.pixel_classes import RecoPixelVariation
 from . import RecoInterface
 
-
-
 class MillipedeWilks(RecoInterface):
     """Reco logic for millipede."""
     # Spline requirements ##############################################
@@ -410,3 +408,5 @@ class MillipedeWilks(RecoInterface):
             totalRecoLossesInside += entry[1]
 
         return totalRecoLossesInside, totalRecoLosses
+
+RECO_CLASS: Final[type[RecoInterface]] = MillipedeWilks

--- a/skymap_scanner/recos/millipede_wilks.py
+++ b/skymap_scanner/recos/millipede_wilks.py
@@ -60,7 +60,7 @@ class MillipedeWilks(RecoInterface):
         self.cascade_service = photonics_service.I3PhotoSplineService(
             abs_spline, prob_spline, timingSigma=0.0,
             effectivedistancetable = effd_spline,
-            tiltTableDir = os.path.expandvars('$I3_BUILD/ice-models/resources/models/ICEMODEL/spice_ftp-v1/')
+            tiltTableDir = os.path.expandvars('$I3_BUILD/ice-models/resources/models/ICEMODEL/spice_ftp-v1/'),
             quantileEpsilon=1
         )
 


### PR DESCRIPTION
Addressing #191 as intermediate step for #189.

This PR decouples the spline staging and instantation of the photospline services from the class declaration, so that importing the class does not trigger file writes or memory allocation by I3PhotoSplineService.

I have the kept the structure of having everything implemented in static attributes / methods, so the class is still not meant to be instantiated, but I am considering taking a step further and changing this as well.

In principle, aside from readability concerns, there is nothing preventing us to define the reconstruction traysegment as a bound method (so I have been told), so instead of:
```
tray.add(RecoAlgo.traysegment)
```
one would have:
```
reco = RecoAlgo(...)
tray.add(reco.traysegment, ...)
```
I think this would provide more flexibility as well as a natural way of implementing configurability for the reconstruction algorithm (see #188).
