### PR TITLE
CI: Wait Only on Server

### DIFF
--- a/resources/launch_scripts/local-scan.sh
+++ b/resources/launch_scripts/local-scan.sh
@@ -41,6 +41,7 @@ fi
     $arg_predictive_scanning_threshold \
     --real-event \
     &
+server_pid=$!
 
 
 # Wait for startup.json
@@ -61,8 +62,7 @@ for i in $( seq 1 $nclients ); do
 done
 
 
-# Wait for Everyone
-wait -n  # for server
-for i in $( seq 1 $nclients ); do
-    wait -n  # for client
-done
+# Wait for scan
+# -- we don't actually care about the clients, if they fail or not
+# -- if all the clients fail, then the sever times out and we can look at client logs
+wait $server_pid


### PR DESCRIPTION
Wait only on the server. We don't actually care about the clients, if they fail or not. Now, if all the clients fail, then the sever times out, the test fails, and we can look at client logs.

This has the effect of allowing one failed client, which forgives some troublesome issues seen occasionally.