### PR TITLE
CI: Failure Resiliant Clients

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ env:
   SKYSCAN_OUTPUT_DIR: /home/runner/work/skymap_scanner/skymap_scanner/output
   SKYSCAN_DEBUG_DIR: /home/runner/work/skymap_scanner/skymap_scanner/debug
   EWMS_PILOT_DUMP_SUBPROC_OUTPUT: False  # get logs in "reco-icetray logs" step instead
+  EWMS_PILOT_STOP_LISTENING_ON_TASK_ERROR: False  # allow a reco to fail (if it keeps failing on redelivery/ies, expect it to affect the scanner server's timeout eventually)
   # see source tests/env-vars.sh
 
 

--- a/dependencies-from-Dockerfile.log
+++ b/dependencies-from-Dockerfile.log
@@ -34,7 +34,7 @@ decorator==4.4.2
 defusedxml==0.7.1
 docutils==0.20.1
 et-xmlfile==1.0.1
-ewms-pilot==0.16.3
+ewms-pilot==0.17.0
 fonttools==4.29.1
 fs==2.4.12
 gast==0.5.2
@@ -249,7 +249,7 @@ scipy==1.8.0
 setuptools==59.6.0
 six==1.16.0
 skymap-scanner
-├── ewms-pilot [required: Any, installed: 0.16.3]
+├── ewms-pilot [required: Any, installed: 0.17.0]
 │   ├── htchirp [required: Any, installed: 2.0]
 │   └── oms-mqclient [required: Any, installed: 2.4.9]
 │       └── wipac-dev-tools [required: Any, installed: 1.7.1]

--- a/dependencies-from-Dockerfile_pulsar.log
+++ b/dependencies-from-Dockerfile_pulsar.log
@@ -34,7 +34,7 @@ decorator==4.4.2
 defusedxml==0.7.1
 docutils==0.20.1
 et-xmlfile==1.0.1
-ewms-pilot==0.16.3
+ewms-pilot==0.17.0
 fonttools==4.29.1
 fs==2.4.12
 gast==0.5.2
@@ -249,7 +249,7 @@ scipy==1.8.0
 setuptools==59.6.0
 six==1.16.0
 skymap-scanner
-├── ewms-pilot [required: Any, installed: 0.16.3]
+├── ewms-pilot [required: Any, installed: 0.17.0]
 │   ├── htchirp [required: Any, installed: 2.0]
 │   └── oms-mqclient [required: Any, installed: 2.4.9]
 │       └── wipac-dev-tools [required: Any, installed: 1.7.1]


### PR DESCRIPTION
Only for CI, clients will not terminate when a reco fails. This allows for the occasional non-deterministic reco failure while allowing the pixel to eventually succeed -- this mimics a production runtime environment, where there are many clients to retry pixels. If the troublesome pixel continues to fail, the scanner server's timeout will eventually lapse and the CI will fail.