### PR TITLE
include incomplete pixels to the to-refine set

### DIFF
--- a/skymap_scanner/server/pixels.py
+++ b/skymap_scanner/server/pixels.py
@@ -118,7 +118,7 @@ def find_pixels_to_refine(
     global_min_pix_nside, global_min_pix_index = find_global_min_pixel(nsides_dict)
     if global_min_pix_index is not None:
         all_refine_pixels = find_pixels_around_pixel(nside, global_min_pix_nside, global_min_pix_index, num=pixel_extension_number)
-        pixels_to_refine.update([x for x in all_refine_pixels if x in pixels_dict])
+        pixels_to_refine.update([x for x in all_refine_pixels])
 
     return [x for x in pixels_to_refine]
 

--- a/skymap_scanner/server/start_scan.py
+++ b/skymap_scanner/server/start_scan.py
@@ -236,13 +236,12 @@ class PixelsToReco:
             while True:
                 # Look up the first available coarser NSIDE by iteratively dividing by two the current nside.
                 # NOTE (v3): this guesswork could be avoided using the NSIDE progression.
-                coarser_nside = coarser_nside/2
-                coarser_pixel = healpy.ang2pix(int(coarser_nside), numpy.pi/2-dec, ra)
-
+                coarser_nside = coarser_nside//2
                 if coarser_nside < self.min_nside:
                     # no coarser pixel is available (probably we are just scanning finely around MC truth)
                     # NOTE (v3): nside != min_side and nside/2 < min_side should be always false? Given the comment above this could have been introduced to support "pointed" scans but this is not currently possible in v3.
                     break
+                coarser_pixel = healpy.ang2pix(coarser_nside, numpy.pi/2-dec, ra)
 
                 if coarser_nside in self.nsides_dict:
                     # NOTE: This is the first nside in the divide-by-two progression that is available in the dictionary. By construction, this should be the previous value in the NSIDE progression.


### PR DESCRIPTION
With the predictive scanning threshold, it's possible that the `pixels_dict` is incomplete when `find_pixels_around_pixel` is called. As is currently implemented,  this makes it possible neighboring pixels which are flagged for refinement would be skipped entirely. 

This is what such a scan looks like, where only the `nside=64` pixels are set to non-nan values. Note the single missing pixel at `nside=8` near the minimum.

<img width="1176" alt="Screenshot 2023-12-01 at 20 58 15" src="https://github.com/icecube/skymap_scanner/assets/5412915/4326718e-0c66-461d-aac3-a95fd6db24ab">

Here, include all pixels which are flagged for refinement irregardless of if they are completed. Technically, this means the term "refinement" is a bit inaccurate, but I think it's probably ok.