### PR TITLE
Remove Unused Pilot Timeout Value

### DIFF
--- a/dependencies-from-Dockerfile.log
+++ b/dependencies-from-Dockerfile.log
@@ -33,16 +33,16 @@ decorator==4.4.2
 defusedxml==0.7.1
 docutils==0.20.1
 et-xmlfile==1.0.1
-ewms-pilot==0.18.6
+ewms-pilot==0.18.7
 fonttools==4.29.1
 fs==2.4.12
 gast==0.5.2
 healpy==1.15.0
 htchirp==3.0
-htcondor==23.5.2
+htcondor==23.6.1
 html5lib==1.1
 hypothesis==6.36.0
-icecube-skyreader==1.2.8
+icecube-skyreader==1.2.9
 idna==3.3
 imagesize==1.4.1
 iminuit==2.25.2
@@ -137,7 +137,7 @@ urwid==2.1.2
 wcwidth==0.2.5
 webencodings==0.5.1
 wipac-dev-tools==1.9.1
-wipac-rest-tools==1.6.1
+wipac-rest-tools==1.7.3
 xlwt==1.3.0
 zipp==1.0.0
 ########################################################################
@@ -212,7 +212,7 @@ pexpect==4.8.0
 pickleshare==0.7.5
 pika==1.3.2
 Pillow==9.0.1
-pipdeptree==2.17.0
+pipdeptree==2.19.1
 ├── packaging [required: >=23.1, installed: 24.0]
 └── pip [required: >=23.1.2, installed: 24.0]
 pluggy==0.13.0
@@ -245,15 +245,15 @@ scipy==1.8.0
 setuptools==59.6.0
 six==1.16.0
 skymap-scanner
-├── ewms-pilot [required: Any, installed: 0.18.6]
+├── ewms-pilot [required: Any, installed: 0.18.7]
 │   ├── htchirp [required: Any, installed: 3.0]
-│   ├── htcondor [required: Any, installed: 23.5.2]
+│   ├── htcondor [required: Any, installed: 23.6.1]
 │   └── oms-mqclient [required: Any, installed: 2.4.10]
 │       └── wipac-dev-tools [required: Any, installed: 1.9.1]
 │           ├── requests [required: Any, installed: 2.25.1]
 │           └── typing_extensions [required: Any, installed: 4.11.0]
 ├── healpy [required: Any, installed: 1.15.0]
-├── icecube-skyreader [required: Any, installed: 1.2.8]
+├── icecube-skyreader [required: Any, installed: 1.2.9]
 │   ├── astropy [required: Any, installed: 5.0.2]
 │   ├── healpy [required: Any, installed: 1.15.0]
 │   ├── matplotlib [required: Any, installed: 3.5.1]
@@ -273,7 +273,7 @@ skymap-scanner
 ├── wipac-dev-tools [required: Any, installed: 1.9.1]
 │   ├── requests [required: Any, installed: 2.25.1]
 │   └── typing_extensions [required: Any, installed: 4.11.0]
-└── wipac-rest-tools [required: Any, installed: 1.6.1]
+└── wipac-rest-tools [required: Any, installed: 1.7.3]
     ├── cachetools [required: Any, installed: 5.3.3]
     ├── PyJWT [required: !=2.6.0, installed: 2.8.0]
     ├── qrcode [required: Any, installed: 7.4.2]

--- a/dependencies-from-Dockerfile.log
+++ b/dependencies-from-Dockerfile.log
@@ -33,7 +33,7 @@ decorator==4.4.2
 defusedxml==0.7.1
 docutils==0.20.1
 et-xmlfile==1.0.1
-ewms-pilot==0.18.7
+ewms-pilot==0.19.0
 fonttools==4.29.1
 fs==2.4.12
 gast==0.5.2
@@ -245,7 +245,7 @@ scipy==1.8.0
 setuptools==59.6.0
 six==1.16.0
 skymap-scanner
-├── ewms-pilot [required: Any, installed: 0.18.7]
+├── ewms-pilot [required: Any, installed: 0.19.0]
 │   ├── htchirp [required: Any, installed: 3.0]
 │   ├── htcondor [required: Any, installed: 23.6.1]
 │   └── oms-mqclient [required: Any, installed: 2.4.10]

--- a/dependencies-from-Dockerfile_no_cvmfs.log
+++ b/dependencies-from-Dockerfile_no_cvmfs.log
@@ -33,16 +33,16 @@ decorator==4.4.2
 defusedxml==0.7.1
 docutils==0.20.1
 et-xmlfile==1.0.1
-ewms-pilot==0.18.6
+ewms-pilot==0.18.7
 fonttools==4.29.1
 fs==2.4.12
 gast==0.5.2
 healpy==1.15.0
 htchirp==3.0
-htcondor==23.5.2
+htcondor==23.6.1
 html5lib==1.1
 hypothesis==6.36.0
-icecube-skyreader==1.2.8
+icecube-skyreader==1.2.9
 idna==3.3
 imagesize==1.4.1
 iminuit==2.25.2
@@ -137,7 +137,7 @@ urwid==2.1.2
 wcwidth==0.2.5
 webencodings==0.5.1
 wipac-dev-tools==1.9.1
-wipac-rest-tools==1.6.1
+wipac-rest-tools==1.7.3
 xlwt==1.3.0
 zipp==1.0.0
 ########################################################################
@@ -212,7 +212,7 @@ pexpect==4.8.0
 pickleshare==0.7.5
 pika==1.3.2
 Pillow==9.0.1
-pipdeptree==2.17.0
+pipdeptree==2.19.1
 ├── packaging [required: >=23.1, installed: 24.0]
 └── pip [required: >=23.1.2, installed: 24.0]
 pluggy==0.13.0
@@ -245,15 +245,15 @@ scipy==1.8.0
 setuptools==59.6.0
 six==1.16.0
 skymap-scanner
-├── ewms-pilot [required: Any, installed: 0.18.6]
+├── ewms-pilot [required: Any, installed: 0.18.7]
 │   ├── htchirp [required: Any, installed: 3.0]
-│   ├── htcondor [required: Any, installed: 23.5.2]
+│   ├── htcondor [required: Any, installed: 23.6.1]
 │   └── oms-mqclient [required: Any, installed: 2.4.10]
 │       └── wipac-dev-tools [required: Any, installed: 1.9.1]
 │           ├── requests [required: Any, installed: 2.25.1]
 │           └── typing_extensions [required: Any, installed: 4.11.0]
 ├── healpy [required: Any, installed: 1.15.0]
-├── icecube-skyreader [required: Any, installed: 1.2.8]
+├── icecube-skyreader [required: Any, installed: 1.2.9]
 │   ├── astropy [required: Any, installed: 5.0.2]
 │   ├── healpy [required: Any, installed: 1.15.0]
 │   ├── matplotlib [required: Any, installed: 3.5.1]
@@ -273,7 +273,7 @@ skymap-scanner
 ├── wipac-dev-tools [required: Any, installed: 1.9.1]
 │   ├── requests [required: Any, installed: 2.25.1]
 │   └── typing_extensions [required: Any, installed: 4.11.0]
-└── wipac-rest-tools [required: Any, installed: 1.6.1]
+└── wipac-rest-tools [required: Any, installed: 1.7.3]
     ├── cachetools [required: Any, installed: 5.3.3]
     ├── PyJWT [required: !=2.6.0, installed: 2.8.0]
     ├── qrcode [required: Any, installed: 7.4.2]

--- a/dependencies-from-Dockerfile_no_cvmfs.log
+++ b/dependencies-from-Dockerfile_no_cvmfs.log
@@ -33,7 +33,7 @@ decorator==4.4.2
 defusedxml==0.7.1
 docutils==0.20.1
 et-xmlfile==1.0.1
-ewms-pilot==0.18.7
+ewms-pilot==0.19.0
 fonttools==4.29.1
 fs==2.4.12
 gast==0.5.2
@@ -245,7 +245,7 @@ scipy==1.8.0
 setuptools==59.6.0
 six==1.16.0
 skymap-scanner
-├── ewms-pilot [required: Any, installed: 0.18.7]
+├── ewms-pilot [required: Any, installed: 0.19.0]
 │   ├── htchirp [required: Any, installed: 3.0]
 │   ├── htcondor [required: Any, installed: 23.6.1]
 │   └── oms-mqclient [required: Any, installed: 2.4.10]

--- a/skymap_scanner/client/client.py
+++ b/skymap_scanner/client/client.py
@@ -95,7 +95,6 @@ def main() -> None:
             ftype_to_subproc=".pkl",
             ftype_from_subproc=".pkl",
             timeout_incoming=cfg.ENV.SKYSCAN_MQ_TIMEOUT_TO_CLIENTS,
-            timeout_outgoing=cfg.ENV.SKYSCAN_MQ_TIMEOUT_FROM_CLIENTS,
             timeout_wait_for_first_message=cfg.ENV.SKYSCAN_MQ_CLIENT_TIMEOUT_WAIT_FOR_FIRST_MESSAGE,
             debug_dir=args.debug_directory,
             task_timeout=cfg.ENV.EWMS_PILOT_TASK_TIMEOUT,


### PR DESCRIPTION
`oms-pilot=0.19.0` removes the previously unused timeout value, `timeout_outgoing`.

see https://github.com/Observation-Management-Service/ewms-pilot/pull/75