### PR TITLE
Patch for an inconsistency introduced in #264

### DIFF
--- a/dependencies-from-Dockerfile.log
+++ b/dependencies-from-Dockerfile.log
@@ -39,13 +39,13 @@ fs==2.4.12
 gast==0.5.2
 healpy==1.15.0
 htchirp==3.0
-htcondor==23.6.1
+htcondor==23.7.2
 html5lib==1.1
 hypothesis==6.36.0
 icecube-skyreader==1.2.9
 idna==3.3
 imagesize==1.4.1
-iminuit==2.25.2
+iminuit==2.26.0
 importlib-metadata==4.6.4
 iniconfig==1.1.1
 ipython==7.31.1
@@ -128,7 +128,7 @@ tables==3.7.0
 toml==0.10.2
 tornado==6.4
 traitlets==5.1.1
-typing_extensions==4.11.0
+typing_extensions==4.12.1
 ufoLib2==0.13.1
 unicodedata2==14.0.0
 UNKNOWN @ file:///root/nuflux-2.0.4
@@ -137,7 +137,7 @@ urwid==2.1.2
 wcwidth==0.2.5
 webencodings==0.5.1
 wipac-dev-tools==1.9.1
-wipac-rest-tools==1.7.3
+wipac-rest-tools==1.7.5
 xlwt==1.3.0
 zipp==1.0.0
 ########################################################################
@@ -212,7 +212,7 @@ pexpect==4.8.0
 pickleshare==0.7.5
 pika==1.3.2
 Pillow==9.0.1
-pipdeptree==2.19.1
+pipdeptree==2.22.0
 ├── packaging [required: >=23.1, installed: 24.0]
 └── pip [required: >=23.1.2, installed: 24.0]
 pluggy==0.13.0
@@ -247,11 +247,11 @@ six==1.16.0
 skymap-scanner
 ├── ewms-pilot [required: Any, installed: 0.19.0]
 │   ├── htchirp [required: Any, installed: 3.0]
-│   ├── htcondor [required: Any, installed: 23.6.1]
+│   ├── htcondor [required: Any, installed: 23.7.2]
 │   └── oms-mqclient [required: Any, installed: 2.4.10]
 │       └── wipac-dev-tools [required: Any, installed: 1.9.1]
 │           ├── requests [required: Any, installed: 2.25.1]
-│           └── typing_extensions [required: Any, installed: 4.11.0]
+│           └── typing_extensions [required: Any, installed: 4.12.1]
 ├── healpy [required: Any, installed: 1.15.0]
 ├── icecube-skyreader [required: Any, installed: 1.2.9]
 │   ├── astropy [required: Any, installed: 5.0.2]
@@ -262,23 +262,23 @@ skymap-scanner
 │   ├── pandas [required: Any, installed: 1.3.5]
 │   └── wipac-dev-tools [required: Any, installed: 1.9.1]
 │       ├── requests [required: Any, installed: 2.25.1]
-│       └── typing_extensions [required: Any, installed: 4.11.0]
-├── iminuit [required: Any, installed: 2.25.2]
+│       └── typing_extensions [required: Any, installed: 4.12.1]
+├── iminuit [required: Any, installed: 2.26.0]
 │   └── numpy [required: >=1.21, installed: 1.21.5]
 ├── numpy [required: Any, installed: 1.21.5]
 ├── oms-mqclient [required: Any, installed: 2.4.10]
 │   └── wipac-dev-tools [required: Any, installed: 1.9.1]
 │       ├── requests [required: Any, installed: 2.25.1]
-│       └── typing_extensions [required: Any, installed: 4.11.0]
+│       └── typing_extensions [required: Any, installed: 4.12.1]
 ├── wipac-dev-tools [required: Any, installed: 1.9.1]
 │   ├── requests [required: Any, installed: 2.25.1]
-│   └── typing_extensions [required: Any, installed: 4.11.0]
-└── wipac-rest-tools [required: Any, installed: 1.7.3]
+│   └── typing_extensions [required: Any, installed: 4.12.1]
+└── wipac-rest-tools [required: Any, installed: 1.7.5]
     ├── cachetools [required: Any, installed: 5.3.3]
     ├── PyJWT [required: !=2.6.0, installed: 2.8.0]
     ├── qrcode [required: Any, installed: 7.4.2]
     │   ├── pypng [required: Any, installed: 0.20220715.0]
-    │   └── typing_extensions [required: Any, installed: 4.11.0]
+    │   └── typing_extensions [required: Any, installed: 4.12.1]
     ├── requests [required: Any, installed: 2.25.1]
     ├── requests-futures [required: Any, installed: 1.0.1]
     │   └── requests [required: >=1.2.0, installed: 2.25.1]
@@ -286,7 +286,7 @@ skymap-scanner
     ├── urllib3 [required: >=2.0.4, installed: 2.2.1]
     └── wipac-dev-tools [required: Any, installed: 1.9.1]
         ├── requests [required: Any, installed: 2.25.1]
-        └── typing_extensions [required: Any, installed: 4.11.0]
+        └── typing_extensions [required: Any, installed: 4.12.1]
 sortedcontainers==2.1.0
 soupsieve==2.3.1
 sympy==1.9

--- a/dependencies-from-Dockerfile.log
+++ b/dependencies-from-Dockerfile.log
@@ -241,7 +241,6 @@ pythran==0.10.0
 pytz==2022.1
 PyYAML==5.4.1
 pyzmq==22.3.0
-scipy==1.8.0
 setuptools==59.6.0
 six==1.16.0
 skymap-scanner
@@ -270,6 +269,7 @@ skymap-scanner
 │   └── wipac-dev-tools [required: Any, installed: 1.9.1]
 │       ├── requests [required: Any, installed: 2.25.1]
 │       └── typing_extensions [required: Any, installed: 4.12.1]
+├── scipy [required: Any, installed: 1.8.0]
 ├── wipac-dev-tools [required: Any, installed: 1.9.1]
 │   ├── requests [required: Any, installed: 2.25.1]
 │   └── typing_extensions [required: Any, installed: 4.12.1]

--- a/dependencies-from-Dockerfile_no_cvmfs.log
+++ b/dependencies-from-Dockerfile_no_cvmfs.log
@@ -39,13 +39,13 @@ fs==2.4.12
 gast==0.5.2
 healpy==1.15.0
 htchirp==3.0
-htcondor==23.6.1
+htcondor==23.7.2
 html5lib==1.1
 hypothesis==6.36.0
 icecube-skyreader==1.2.9
 idna==3.3
 imagesize==1.4.1
-iminuit==2.25.2
+iminuit==2.26.0
 importlib-metadata==4.6.4
 iniconfig==1.1.1
 ipython==7.31.1
@@ -128,7 +128,7 @@ tables==3.7.0
 toml==0.10.2
 tornado==6.4
 traitlets==5.1.1
-typing_extensions==4.11.0
+typing_extensions==4.12.1
 ufoLib2==0.13.1
 unicodedata2==14.0.0
 UNKNOWN @ file:///root/nuflux-2.0.4
@@ -137,7 +137,7 @@ urwid==2.1.2
 wcwidth==0.2.5
 webencodings==0.5.1
 wipac-dev-tools==1.9.1
-wipac-rest-tools==1.7.3
+wipac-rest-tools==1.7.5
 xlwt==1.3.0
 zipp==1.0.0
 ########################################################################
@@ -212,7 +212,7 @@ pexpect==4.8.0
 pickleshare==0.7.5
 pika==1.3.2
 Pillow==9.0.1
-pipdeptree==2.19.1
+pipdeptree==2.22.0
 ├── packaging [required: >=23.1, installed: 24.0]
 └── pip [required: >=23.1.2, installed: 24.0]
 pluggy==0.13.0
@@ -247,11 +247,11 @@ six==1.16.0
 skymap-scanner
 ├── ewms-pilot [required: Any, installed: 0.19.0]
 │   ├── htchirp [required: Any, installed: 3.0]
-│   ├── htcondor [required: Any, installed: 23.6.1]
+│   ├── htcondor [required: Any, installed: 23.7.2]
 │   └── oms-mqclient [required: Any, installed: 2.4.10]
 │       └── wipac-dev-tools [required: Any, installed: 1.9.1]
 │           ├── requests [required: Any, installed: 2.25.1]
-│           └── typing_extensions [required: Any, installed: 4.11.0]
+│           └── typing_extensions [required: Any, installed: 4.12.1]
 ├── healpy [required: Any, installed: 1.15.0]
 ├── icecube-skyreader [required: Any, installed: 1.2.9]
 │   ├── astropy [required: Any, installed: 5.0.2]
@@ -262,23 +262,23 @@ skymap-scanner
 │   ├── pandas [required: Any, installed: 1.3.5]
 │   └── wipac-dev-tools [required: Any, installed: 1.9.1]
 │       ├── requests [required: Any, installed: 2.25.1]
-│       └── typing_extensions [required: Any, installed: 4.11.0]
-├── iminuit [required: Any, installed: 2.25.2]
+│       └── typing_extensions [required: Any, installed: 4.12.1]
+├── iminuit [required: Any, installed: 2.26.0]
 │   └── numpy [required: >=1.21, installed: 1.21.5]
 ├── numpy [required: Any, installed: 1.21.5]
 ├── oms-mqclient [required: Any, installed: 2.4.10]
 │   └── wipac-dev-tools [required: Any, installed: 1.9.1]
 │       ├── requests [required: Any, installed: 2.25.1]
-│       └── typing_extensions [required: Any, installed: 4.11.0]
+│       └── typing_extensions [required: Any, installed: 4.12.1]
 ├── wipac-dev-tools [required: Any, installed: 1.9.1]
 │   ├── requests [required: Any, installed: 2.25.1]
-│   └── typing_extensions [required: Any, installed: 4.11.0]
-└── wipac-rest-tools [required: Any, installed: 1.7.3]
+│   └── typing_extensions [required: Any, installed: 4.12.1]
+└── wipac-rest-tools [required: Any, installed: 1.7.5]
     ├── cachetools [required: Any, installed: 5.3.3]
     ├── PyJWT [required: !=2.6.0, installed: 2.8.0]
     ├── qrcode [required: Any, installed: 7.4.2]
     │   ├── pypng [required: Any, installed: 0.20220715.0]
-    │   └── typing_extensions [required: Any, installed: 4.11.0]
+    │   └── typing_extensions [required: Any, installed: 4.12.1]
     ├── requests [required: Any, installed: 2.25.1]
     ├── requests-futures [required: Any, installed: 1.0.1]
     │   └── requests [required: >=1.2.0, installed: 2.25.1]
@@ -286,7 +286,7 @@ skymap-scanner
     ├── urllib3 [required: >=2.0.4, installed: 2.2.1]
     └── wipac-dev-tools [required: Any, installed: 1.9.1]
         ├── requests [required: Any, installed: 2.25.1]
-        └── typing_extensions [required: Any, installed: 4.11.0]
+        └── typing_extensions [required: Any, installed: 4.12.1]
 sortedcontainers==2.1.0
 soupsieve==2.3.1
 sympy==1.9

--- a/dependencies-from-Dockerfile_no_cvmfs.log
+++ b/dependencies-from-Dockerfile_no_cvmfs.log
@@ -241,7 +241,6 @@ pythran==0.10.0
 pytz==2022.1
 PyYAML==5.4.1
 pyzmq==22.3.0
-scipy==1.8.0
 setuptools==59.6.0
 six==1.16.0
 skymap-scanner
@@ -270,6 +269,7 @@ skymap-scanner
 │   └── wipac-dev-tools [required: Any, installed: 1.9.1]
 │       ├── requests [required: Any, installed: 2.25.1]
 │       └── typing_extensions [required: Any, installed: 4.12.1]
+├── scipy [required: Any, installed: 1.8.0]
 ├── wipac-dev-tools [required: Any, installed: 1.9.1]
 │   ├── requests [required: Any, installed: 2.25.1]
 │   └── typing_extensions [required: Any, installed: 4.12.1]

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
 	icecube-skyreader
 	iminuit
 	numpy
+  scipy
 	oms-mqclient
 	wipac-dev-tools
 	wipac-rest-tools

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,8 @@ install_requires =
 	icecube-skyreader
 	iminuit
 	numpy
-  scipy
 	oms-mqclient
+	scipy
 	wipac-dev-tools
 	wipac-rest-tools
 python_requires = >=3.9, <3.12

--- a/skymap_scanner/recos/millipede_wilks.py
+++ b/skymap_scanner/recos/millipede_wilks.py
@@ -138,7 +138,7 @@ class MillipedeWilks(RecoInterface):
         exclusionList = \
         tray.AddSegment(millipede.HighEnergyExclusions, 'millipede_DOM_exclusions',
             Pulses = cls.pulsesName,
-            ExcludeDeepCore=False,
+            ExcludeDeepCore='DeepCoreDOMs',
             ExcludeSaturatedDOMs='SaturatedDOMs',
             ExcludeBrightDOMs='BrightDOMs',
             BrightDOMThreshold=2,


### PR DESCRIPTION
Since the pulseseries masks DC DOMs we should still flag DeepCoreDOMs in the exclusions.